### PR TITLE
Add feature_id to ExperimentResult, fix bug when hashAttribute is not a string

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Run unit tests with `bundler exec rspec`
 
 ## Releasing
 
-1. Bump version in `Gemfile` and `Gemfile.lock`
+1. Bump version in `Gemfile.lock` and `growthbook.gemspec`
 2. Merge to the `main` branch
 3. Create a new GitHub release with the new version as the tag (e.g. `v0.2.0`)
 4. Run `gem build growthbook`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    growthbook (0.2.0)
+    growthbook (0.3.0)
       fnv (~> 0.2.0)
 
 GEM

--- a/growthbook.gemspec
+++ b/growthbook.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = 'growthbook'
-  s.version       = '0.2.0'
+  s.version       = '0.3.0'
   s.summary       = 'GrowthBook SDK for Ruby'
   s.description   = 'Official GrowthBook SDK for Ruby'
   s.authors       = ['GrowthBook']

--- a/lib/growthbook/inline_experiment_result.rb
+++ b/lib/growthbook/inline_experiment_result.rb
@@ -26,13 +26,16 @@ module Growthbook
     # @return [String]
     attr_reader :hash_value
 
+    attr_reader :feature_id
+
     def initialize(
       hash_used,
       in_experiment,
       variation_id,
       value,
       hash_attribute,
-      hash_value
+      hash_value,
+      feature_id
     )
 
       @hash_used = hash_used
@@ -41,6 +44,7 @@ module Growthbook
       @value = value
       @hash_attribute = hash_attribute
       @hash_value = hash_value
+      @feature_id = feature_id
     end
 
     def to_json(*_args)
@@ -51,6 +55,7 @@ module Growthbook
       res['value'] = @value
       res['hashAttribute'] = @hash_attribute
       res['hashValue'] = @hash_value
+      res['featureId'] = @feature_id.to_s
       res
     end
   end

--- a/spec/cases.json
+++ b/spec/cases.json
@@ -1,4 +1,5 @@
 {
+  "specVersion": "0.2.2",
   "evalCondition": [
     [
       "$not - pass",
@@ -1704,6 +1705,7 @@
           "variations": ["a", "b", "c"]
         },
         "experimentResult": {
+          "featureId": "feature",
           "value": "c",
           "variationId": 2,
           "inExperiment": true,
@@ -1740,6 +1742,7 @@
           "variations": ["a", "b", "c"]
         },
         "experimentResult": {
+          "featureId": "feature",
           "value": "a",
           "variationId": 0,
           "inExperiment": true,
@@ -1776,6 +1779,7 @@
           "variations": ["a", "b", "c"]
         },
         "experimentResult": {
+          "featureId": "feature",
           "value": "b",
           "variationId": 1,
           "inExperiment": true,
@@ -1824,6 +1828,7 @@
           "weights": [0.1, 0.9]
         },
         "experimentResult": {
+          "featureId": "feature",
           "value": false,
           "variationId": 1,
           "inExperiment": true,
@@ -1990,6 +1995,42 @@
       }
     ],
     [
+      "handles integer hashAttribute",
+      {
+        "attributes": { "id": 123 },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "key": "feature",
+          "variations": [0, 1]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "hashAttribute": "id",
+          "hashValue": 123,
+          "hashUsed": true,
+          "inExperiment": true,
+          "value": 1,
+          "variationId": 1
+        }
+      }
+    ],
+    [
       "skip experiment on missing hashAttribute",
       {
         "attributes": { "id": "123" },
@@ -2048,6 +2089,7 @@
           "variations": [0, 1, 2, 3]
         },
         "experimentResult": {
+          "featureId": "feature",
           "value": 1,
           "variationId": 1,
           "inExperiment": true,
@@ -2366,6 +2408,14 @@
     [
       "empty id",
       { "attributes": { "id": "" } },
+      { "key": "my-test", "variations": [0, 1] },
+      0,
+      false,
+      false
+    ],
+    [
+      "null id",
+      { "attributes": { "id": null } },
       { "key": "my-test", "variations": [0, 1] },
       0,
       false,

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -95,6 +95,7 @@ describe 'context' do
       gb.on? :feature1
 
       expect(gb.impressions["feature1"].to_json).to eq({
+        "featureId" => "feature1",
         "hashAttribute" => "id",
         "hashValue" => "123",
         "inExperiment" => true,
@@ -109,6 +110,7 @@ describe 'context' do
           "variations" => [2, 3]
         },
         {
+          "featureId" => "feature1",
           "hashAttribute" => "id",
           "hashValue" => "123",
           "inExperiment" => true,


### PR DESCRIPTION
Using latest GrowthBook SDK spec, version 0.2.2

TODO:
- [x] Bump version