### PR TITLE
Support v0.4.0 spec

### DIFF
--- a/lib/growthbook/context.rb
+++ b/lib/growthbook/context.rb
@@ -2,8 +2,28 @@
 
 module Growthbook
   class Context
-    attr_accessor :enabled, :url, :qa_mode, :listener
-    attr_reader :attributes, :features, :impressions, :forced_variations, :forced_features
+    # @return [true, false] Switch to globally disable all experiments. Default true.
+    attr_accessor :enabled
+
+    # @return [String] The URL of the current page
+    attr_accessor :url
+
+    # @return [true, false, nil] If true, random assignment is disabled and only explicitly forced variations are used.
+    attr_accessor :qa_mode
+
+    # @return [Listener] An object that responds to some tracking methods that take experiment and result as arguments.
+    attr_accessor :listener
+
+    # @return [Hash] Map of user attributes that are used to assign variations
+    attr_reader :attributes
+
+    # @return [Hash] Feature definitions (usually pulled from an API or cache)
+    attr_reader :features
+
+    # @return [Hash] Force specific experiments to always assign a specific variation (used for QA)
+    attr_reader :forced_variations
+
+    attr_reader :impressions, :forced_features
 
     def initialize(options = {})
       @features = {}
@@ -201,8 +221,10 @@ module Growthbook
       hash_attribute = experiment.hash_attribute || 'id'
       hash_value = get_attribute(hash_attribute)
 
-      Growthbook::InlineExperimentResult.new(hash_used, in_experiment, variation_index,
-                                             experiment.variations[variation_index], hash_attribute, hash_value, feature_id)
+      Growthbook::InlineExperimentResult.new(
+        { in_experiment: in_experiment, variation_id: variation_index, value: experiment.variations[variation_index],
+          hash_used: hash_used, hash_attribute: hash_attribute, hash_value: hash_value, feature_id: feature_id }
+      )
     end
 
     def get_feature_result(value, source, experiment = nil, experiment_result = nil)

--- a/lib/growthbook/feature_rule.rb
+++ b/lib/growthbook/feature_rule.rb
@@ -2,22 +2,40 @@
 
 module Growthbook
   class FeatureRule
-    # @return [Hash , nil]
+    # @return [Hash , nil] Optional targeting condition
     attr_reader :condition
-    # @return [Float , nil]
+    # @return [Float , nil] What percent of users should be included in the experiment (between 0 and 1, inclusive)
     attr_reader :coverage
-    # @return [T , nil]
+    # @return [T , nil] Immediately force a specific value (ignore every other option besides condition and coverage)
     attr_reader :force
-    # @return [T[] , nil]
+    # @return [T[] , nil] Run an experiment (A/B test) and randomly choose between these variations
     attr_reader :variations
-    # @return [String , nil]
+    # @return [String , nil] The globally unique tracking key for the experiment (default to the feature key)
     attr_reader :key
-    # @return [Float[] , nil]
+    # @return [Float[] , nil] How to weight traffic between variations. Must add to 1.
     attr_reader :weights
-    # @return [Array , nil]
+    # @return [String , nil] Adds the experiment to a namespace
     attr_reader :namespace
-    # @return [String , nil]
+    # @return [String , nil] What user attribute should be used to assign variations (defaults to id)
     attr_reader :hash_attribute
+    # @return [Integer , nil] The hash version to use (default to 1)
+    attr_reader :hash_version
+    # @return [BucketRange , nil] A more precise version of coverage
+    attr_reader :range
+    # @return [BucketRanges[] , nil] Ranges for experiment variations
+    attr_reader :ranges
+    # @return [VariationMeta[] , nil] Meta info about the experiment variations
+    attr_reader :meta
+    # @return [Filter[] , nil] Array of filters to apply to the rule
+    attr_reader :filters
+    # @return [String , nil]  Seed to use for hashing
+    attr_reader :seed
+    # @return [String , nil] Human-readable name for the experiment
+    attr_reader :name
+    # @return [String , nil] The phase id of the experiment
+    attr_reader :phase
+    # @return [TrackData[] , nil] Array of tracking calls to fire
+    attr_reader :tracks
 
     def initialize(rule)
       @coverage = getOption(rule, :coverage)
@@ -27,6 +45,15 @@ module Growthbook
       @weights = getOption(rule, :weights)
       @namespace = getOption(rule, :namespace)
       @hash_attribute = getOption(rule, :hash_attribute) || getOption(rule, :hashAttribute)
+      @hash_version = getOption(rule, :hash_version) || getOption(rule, :hashVersion)
+      @range = getOption(rule, :range)
+      @ranges = getOption(rule, :ranges)
+      @meta = getOption(rule, :meta)
+      @filters = getOption(rule, :filters)
+      @seed = getOption(rule, :seed)
+      @name = getOption(rule, :name)
+      @phase = getOption(rule, :phase)
+      @tracks = getOption(rule, :tracks)
 
       cond = getOption(rule, :condition)
       @condition = Growthbook::Conditions.parse_condition(cond) unless cond.nil?
@@ -41,7 +68,14 @@ module Growthbook
         coverage: @coverage,
         weights: @weights,
         hash_attribute: @hash_attribute,
-        namespace: @namespace
+        hash_version: @hash_version,
+        namespace: @namespace,
+        meta: @meta,
+        ranges: @ranges,
+        filters: @filters,
+        name: @name,
+        phase: @phase,
+        seed: @seed,
       )
     end
 
@@ -54,16 +88,24 @@ module Growthbook
     end
 
     def to_json(*_args)
-      res = {}
-      res['condition'] = @condition unless @condition.nil?
-      res['coverage'] = @coverage unless @coverage.nil?
-      res['force'] = @force unless @force.nil?
-      res['variations'] = @variations unless @variations.nil?
-      res['key'] = @key unless @key.nil?
-      res['weights'] = @weights unless @weights.nil?
-      res['namespace'] = @namespace unless @namespace.nil?
-      res['hashAttribute'] = @hash_attribute unless @hash_attribute.nil?
-      res
+      {
+        'condition' => @condition,
+        'coverage' => @coverage,
+        'force' => @force,
+        'variations' => @variations,
+        'key' => @key,
+        'weights' => @weights,
+        'namespace' => @namespace,
+        'hashAttribute' => @hash_attribute,
+        'range' => @range,
+        'ranges' => @ranges,
+        'meta' => @meta,
+        'filters' => @filters,
+        'seed' => @seed,
+        'name' => @name,
+        'phase' => @phase,
+        'tracks' => @tracks
+      }.compact
     end
 
     private

--- a/lib/growthbook/inline_experiment.rb
+++ b/lib/growthbook/inline_experiment.rb
@@ -2,58 +2,71 @@
 
 module Growthbook
   class InlineExperiment
-    # @returns [String]
+    # @returns [String] The globally unique identifier for the experiment
     attr_accessor :key
 
-    # @returns [Any]
+    # @returns [Array<String, Integer, Hash>] The different variations to choose between
     attr_accessor :variations
 
-    # @returns [Bool]
-    attr_accessor :active
-
-    # @returns [Integer, nil]
-    attr_accessor :force
-
-    # @returns [Array<Float>, nil]
+    # @returns [Array<Float>] How to weight traffic between variations. Must add to 1.
     attr_accessor :weights
 
-    # @returns [Float]
+    # @returns [true, false] If set to false, always return the control (first variation)
+    attr_accessor :active
+
+    # @returns [Float] What percent of users should be included in the experiment (between 0 and 1, inclusive)
     attr_accessor :coverage
 
-    # @returns [Hash, nil]
+    # @returns [Array<Hash>] Array of ranges, one per variation
+    attr_accessor :ranges
+
+    # @returns [Hash] Optional targeting condition
     attr_accessor :condition
 
-    # @returns [Array]
+    # @returns [String, nil] Adds the experiment to a namespace
     attr_accessor :namespace
 
-    # @returns [String]
+    # @returns [integer, nil] All users included in the experiment will be forced into the specific variation index
+    attr_accessor :force
+
+    # @returns [String] What user attribute should be used to assign variations (defaults to id)
     attr_accessor :hash_attribute
 
-    # Constructor for an Experiment
-    #
-    # @param options [Hash]
-    # @option options [Array<Any>] :variations The variations to pick between
-    # @option options [String] :key The unique identifier for this experiment
-    # @option options [Float] :coverage (1.0) The percent of elegible traffic to include in the experiment
-    # @option options [Array<Float>] :weights The relative weights of the variations.
-    #    Length must be the same as the number of variations. Total should add to 1.0.
-    #    Default is an even split between variations
-    # @option options [Boolean] :anon (false) If false, the experiment uses the logged-in user id for bucketing
-    #    If true, the experiment uses the anonymous id for bucketing
-    # @option options [Array<String>] :targeting Array of targeting rules in the format "key op value"
-    #    where op is one of: =, !=, <, >, ~, !~
-    # @option options [Integer, nil] :force If an integer, force all users to get this variation
-    # @option options [Hash] :data Data to attach to the variations
+    # @returns [Integer] The hash version to use (default to 1)
+    attr_accessor :hash_version
+
+    # @returns [Array<Hash>] Meta info about the variations
+    attr_accessor :meta
+
+    # @returns [Array<Hash>] Array of filters to apply
+    attr_accessor :filters
+
+    # @returns [String, nil] The hash seed to use
+    attr_accessor :seed
+
+    # @returns [String] Human-readable name for the experiment
+    attr_accessor :name
+
+    # @returns [String, nil] Id of the current experiment phase
+    attr_accessor :phase
+
     def initialize(options = {})
       @key = getOption(options, :key, '').to_s
       @variations = getOption(options, :variations, [])
-      @active = getOption(options, :active, true)
-      @force = getOption(options, :force)
       @weights = getOption(options, :weights)
+      @active = getOption(options, :active, true)
       @coverage = getOption(options, :coverage, 1)
+      @ranges = getOption(options, :ranges)
       @condition = getOption(options, :condition)
       @namespace = getOption(options, :namespace)
+      @force = getOption(options, :force)
       @hash_attribute = getOption(options, :hash_attribute) || getOption(options, :hashAttribute) || 'id'
+      @hash_version = getOption(options, :hash_version) || getOption(options, :hashVersion)
+      @meta = getOption(options, :meta)
+      @filters = getOption(options, :filters)
+      @seed = getOption(options, :seed)
+      @name = getOption(options, :name)
+      @phase = getOption(options, :phase)
     end
 
     def getOption(hash, key, default = nil)
@@ -67,14 +80,21 @@ module Growthbook
       res = {}
       res['key'] = @key
       res['variations'] = @variations
-      res['active'] = @active if @active != true && !@active.nil?
-      res['force'] = @force unless @force.nil?
       res['weights'] = @weights unless @weights.nil?
+      res['active'] = @active if @active != true && !@active.nil?
       res['coverage'] = @coverage if @coverage != 1 && !@coverage.nil?
-      res['condition'] = @condition unless @condition.nil?
-      res['namespace'] = @namespace unless @namespace.nil?
+      res['ranges'] = @ranges
+      res['condition'] = @condition
+      res['namespace'] = @namespace
+      res['force'] = @force unless @force.nil?
       res['hashAttribute'] = @hash_attribute if @hash_attribute != 'id' && !@hash_attribute.nil?
-      res
+      res['hashVersion'] = @hash_version
+      res['meta'] = @meta
+      res['filters'] = @filters
+      res['seed'] = @seed
+      res['name'] = @name
+      res['phase'] = @phase
+      res.compact
     end
   end
 end

--- a/lib/growthbook/inline_experiment_result.rb
+++ b/lib/growthbook/inline_experiment_result.rb
@@ -2,61 +2,67 @@
 
 module Growthbook
   class InlineExperimentResult
-    # Whether or not the user is in the experiment
-    # @return [Bool]
+    # @return [Boolean] Whether or not the user is part of the experiment
     attr_reader :in_experiment
 
-    # The array index of the assigned variation
-    # @return [Integer]
+    # @return [Integer] The array index of the assigned variation
     attr_reader :variation_id
 
-    # The assigned variation value
-    # @return [Any]
+    # @return [Any] The array value of the assigned variation
     attr_reader :value
 
-    # If the variation was randomly assigned based on user attribute hashes
-    # @return [Bool]
+    # @return [Bool] If a hash was used to assign a variation
     attr_reader :hash_used
 
-    # The attribute used to split traffic
-    # @return [String]
+    # @return [String] The user attribute used to assign a variation
     attr_reader :hash_attribute
 
-    # The value of the hashAttribute
-    # @return [String]
+    # @return [String] The value of that attribute
     attr_reader :hash_value
 
+    # @return [String, nil] The id of the feature (if any) that the experiment came from
     attr_reader :feature_id
 
-    def initialize(
-      hash_used,
-      in_experiment,
-      variation_id,
-      value,
-      hash_attribute,
-      hash_value,
-      feature_id
-    )
+    # @return [String] The unique key for the assigned variation
+    attr_reader :key
 
-      @hash_used = hash_used
-      @in_experiment = in_experiment
-      @variation_id = variation_id
-      @value = value
-      @hash_attribute = hash_attribute
-      @hash_value = hash_value
-      @feature_id = feature_id
+    # @return [Float] The hash value used to assign a variation (float from 0 to 1)
+    attr_reader :bucket
+
+    # @return [String , nil] Human-readable name for the experiment
+    attr_reader :name
+
+    # @return [Boolean]  Used for holdout groups
+    attr_accessor :passthrough
+
+    def initialize(options = {})
+      @key = options[:key]
+      @in_experiment = options[:in_experiment]
+      @variation_id = options[:variation_id]
+      @value = options[:value]
+      @hash_used = options[:hash_used]
+      @hash_attribute = options[:hash_attribute]
+      @hash_value = options[:hash_value]
+      @feature_id = options[:feature_id]
+      @bucket = options[:bucket]
+      @name = options[:name]
+      @passthrough = options[:passthrough]
     end
 
     def to_json(*_args)
-      res = {}
-      res['inExperiment'] = @in_experiment
-      res['hashUsed'] = @hash_used
-      res['variationId'] = @variation_id
-      res['value'] = @value
-      res['hashAttribute'] = @hash_attribute
-      res['hashValue'] = @hash_value
-      res['featureId'] = @feature_id.to_s
-      res
+      {
+        'inExperiment' => @in_experiment,
+        'variationId' => @variation_id,
+        'value' => @value,
+        'hashUsed' => @hash_used,
+        'hashAttribute' => @hash_attribute,
+        'hashValue' => @hash_value,
+        'featureId' => @feature_id.to_s,
+        'key' => @key.to_s,
+        'bucket' => @bucket,
+        'name' => @name,
+        'passthrough' => @passthrough
+      }.compact
     end
   end
 end

--- a/lib/growthbook/util.rb
+++ b/lib/growthbook/util.rb
@@ -62,12 +62,15 @@ module Growthbook
       match
     end
 
-    def self.hash(str)
-      (FNV.new.fnv1a_32(str) % 1000) / 1000.0
+    def self.hash(seed:, value:, version:)
+      return (FNV.new.fnv1a_32(value + seed) % 1000) / 1000.0 if version == 1
+      return (FNV.new.fnv1a_32(FNV.new.fnv1a_32(seed + value).to_s) % 10000) / 10000.0 if version == 2
+
+      -1
     end
 
-    def self.in_namespace(userId, namespace)
-      n = hash("#{userId}__#{namespace[0]}")
+    def self.in_namespace(hash_value, namespace)
+      n = hash(seed: "__" + namespace[0], value: hash_value, version: 1)
       n >= namespace[1] && n < namespace[2]
     end
 
@@ -147,6 +150,10 @@ module Growthbook
       return nil if n >= numVariations
 
       n
+    end
+
+    def self.in_range(n, range)
+      n >= range[0] && n < range[1]
     end
   end
 end

--- a/spec/cases.json
+++ b/spec/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.2.2",
+  "specVersion": "0.4.0",
   "evalCondition": [
     [
       "$not - pass",
@@ -1317,13 +1317,21 @@
     ]
   ],
   "hash": [
-    ["a", 0.22],
-    ["b", 0.077],
-    ["ab", 0.946],
-    ["def", 0.652],
-    ["8952klfjas09ujkasdf", 0.549],
-    ["123", 0.011],
-    ["___)((*\":&", 0.563]
+    ["", "a", 1, 0.22],
+    ["", "b", 1, 0.077],
+    ["b", "a", 1, 0.946],
+    ["ef", "d", 1, 0.652],
+    ["asdf", "8952klfjas09ujk", 1, 0.549],
+    ["", "123", 1, 0.011],
+    ["", "___)((*\":&", 1, 0.563],
+    ["seed", "a", 2, 0.0505],
+    ["seed", "b", 2, 0.2696],
+    ["foo", "ab", 2, 0.2575],
+    ["foo", "def", 2, 0.2019],
+    ["89123klj", "8952klfjas09ujkasdf", 2, 0.124],
+    ["90850943850283058242805", "123", 2, 0.7516],
+    ["()**(%$##$%#$#", "___)((*\":&", 2, 0.0128],
+    ["abc", "def", 99, -1]
   ],
   "getBucketRange": [
     [
@@ -1711,7 +1719,9 @@
           "inExperiment": true,
           "hashUsed": true,
           "hashAttribute": "id",
-          "hashValue": "123"
+          "hashValue": "123",
+          "bucket": 0.863,
+          "key": "2"
         },
         "source": "experiment"
       }
@@ -1748,7 +1758,9 @@
           "inExperiment": true,
           "hashUsed": true,
           "hashAttribute": "id",
-          "hashValue": "456"
+          "hashValue": "456",
+          "bucket": 0.178,
+          "key": "0"
         },
         "source": "experiment"
       }
@@ -1785,7 +1797,9 @@
           "inExperiment": true,
           "hashUsed": true,
           "hashAttribute": "id",
-          "hashValue": "fds"
+          "hashValue": "fds",
+          "bucket": 0.514,
+          "key": "1"
         },
         "source": "experiment"
       }
@@ -1803,6 +1817,31 @@
               {
                 "coverage": 0.99,
                 "hashAttribute": "anonId",
+                "seed": "feature",
+                "hashVersion": 2,
+                "name": "Test",
+                "phase": "1",
+                "ranges": [
+                  [0, 0.1],
+                  [0.1, 1.0]
+                ],
+                "meta": [
+                  {
+                    "key": "v0",
+                    "name": "variation 0"
+                  },
+                  {
+                    "key": "v1",
+                    "name": "variation 1"
+                  }
+                ],
+                "filters": [
+                  {
+                    "attribute": "anonId",
+                    "seed": "pricing",
+                    "ranges": [[0, 1]]
+                  }
+                ],
                 "namespace": ["pricing", 0, 1],
                 "key": "hello",
                 "variations": [true, false],
@@ -1821,6 +1860,31 @@
         "source": "experiment",
         "experiment": {
           "coverage": 0.99,
+          "ranges": [
+            [0, 0.1],
+            [0.1, 1.0]
+          ],
+          "meta": [
+            {
+              "key": "v0",
+              "name": "variation 0"
+            },
+            {
+              "key": "v1",
+              "name": "variation 1"
+            }
+          ],
+          "filters": [
+            {
+              "attribute": "anonId",
+              "seed": "pricing",
+              "ranges": [[0, 1]]
+            }
+          ],
+          "name": "Test",
+          "phase": "1",
+          "seed": "feature",
+          "hashVersion": 2,
           "hashAttribute": "anonId",
           "namespace": ["pricing", 0, 1],
           "key": "hello",
@@ -1834,7 +1898,10 @@
           "inExperiment": true,
           "hashUsed": true,
           "hashAttribute": "anonId",
-          "hashValue": "123"
+          "hashValue": "123",
+          "bucket": 0.5231,
+          "key": "v1",
+          "name": "variation 1"
         }
       }
     ],
@@ -2026,7 +2093,9 @@
           "hashUsed": true,
           "inExperiment": true,
           "value": 1,
-          "variationId": 1
+          "variationId": 1,
+          "key": "1",
+          "bucket": 0.863
         }
       }
     ],
@@ -2095,7 +2164,285 @@
           "inExperiment": true,
           "hashUsed": false,
           "hashAttribute": "id",
-          "hashValue": "123"
+          "hashValue": "123",
+          "key": "1"
+        }
+      }
+    ],
+    [
+      "Force rule with range, ignores coverage",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 2,
+                "coverage": 0.01,
+                "range": [0, 0.99]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 2,
+        "on": true,
+        "off": false,
+        "source": "force"
+      }
+    ],
+    [
+      "Force rule, hash version 2",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 2,
+                "hashVersion": 2,
+                "range": [0.96, 0.97]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 2,
+        "on": true,
+        "off": false,
+        "source": "force"
+      }
+    ],
+    [
+      "Force rule, skip due to range",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 2,
+                "range": [0, 0.01]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue"
+      }
+    ],
+    [
+      "Force rule, skip due to filter",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 2,
+                "filters": [
+                  {
+                    "seed": "seed",
+                    "ranges": [[0, 0.01]]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue"
+      }
+    ],
+    [
+      "Force rule, use seed with range",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 2,
+                "range": [0, 0.5],
+                "seed": "fjdslafdsa",
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 2,
+        "on": true,
+        "off": false,
+        "source": "force"
+      }
+    ],
+    [
+      "Support passthrough variations",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "holdout",
+                "variations": [1, 2],
+                "hashVersion": 2,
+                "ranges": [
+                  [0, 0.01],
+                  [0.01, 1.0]
+                ],
+                "meta": [
+                  {},
+                  {
+                    "passthrough": true
+                  }
+                ]
+              },
+              {
+                "key": "experiment",
+                "variations": [3, 4],
+                "hashVersion": 2,
+                "ranges": [
+                  [0, 0.5],
+                  [0.5, 1.0]
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 3,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "key": "experiment",
+          "hashVersion": 2,
+          "variations": [3, 4],
+          "ranges": [
+            [0, 0.5],
+            [0.5, 1.0]
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "hashAttribute": "id",
+          "hashUsed": true,
+          "hashValue": "1",
+          "inExperiment": true,
+          "key": "0",
+          "value": 3,
+          "variationId": 0,
+          "bucket": 0.4413
+        }
+      }
+    ],
+    [
+      "Support holdout groups",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "holdout",
+                "hashVersion": 2,
+                "variations": [1, 2],
+                "ranges": [
+                  [0, 0.99],
+                  [0.99, 1.0]
+                ],
+                "meta": [
+                  {},
+                  {
+                    "passthrough": true
+                  }
+                ]
+              },
+              {
+                "key": "experiment",
+                "hashVersion": 2,
+                "variations": [3, 4],
+                "ranges": [
+                  [0, 0.5],
+                  [0.5, 1.0]
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "hashVersion": 2,
+          "ranges": [
+            [0, 0.99],
+            [0.99, 1.0]
+          ],
+          "meta": [
+            {},
+            {
+              "passthrough": true
+            }
+          ],
+          "key": "holdout",
+          "variations": [1, 2]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "hashAttribute": "id",
+          "hashUsed": true,
+          "hashValue": "1",
+          "inExperiment": true,
+          "key": "0",
+          "value": 1,
+          "variationId": 0,
+          "bucket": 0.8043
         }
       }
     ]
@@ -2730,6 +3077,204 @@
       0,
       false,
       false
+    ],
+    [
+      "Experiment coverage - Works when 0",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "no-coverage",
+        "variations": [0, 1],
+        "coverage": 0
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "Filtered, included",
+      {
+        "attributes": {
+          "id": "1",
+          "anonId": "fsdafsda"
+        }
+      },
+      {
+        "key": "filtered",
+        "variations": [0, 1],
+        "filters": [
+          {
+            "seed": "seed",
+            "ranges": [
+              [0, 0.1],
+              [0.2, 0.4]
+            ]
+          },
+          {
+            "seed": "seed",
+            "attribute": "anonId",
+            "ranges": [[0.8, 1.0]]
+          }
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Filtered, excluded",
+      {
+        "attributes": {
+          "id": "1",
+          "anonId": "fsdafsda"
+        }
+      },
+      {
+        "key": "filtered",
+        "variations": [0, 1],
+        "filters": [
+          {
+            "seed": "seed",
+            "ranges": [
+              [0, 0.1],
+              [0.2, 0.4]
+            ]
+          },
+          {
+            "seed": "seed",
+            "attribute": "anonId",
+            "ranges": [[0.6, 0.8]]
+          }
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "Filtered, ignore namespace",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "filtered",
+        "variations": [0, 1],
+        "filters": [
+          {
+            "seed": "seed",
+            "ranges": [
+              [0, 0.1],
+              [0.2, 0.4]
+            ]
+          }
+        ],
+        "namespace": ["test", 0, 0.001]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Ranges, ignore coverage and weights",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "ranges",
+        "variations": [0, 1],
+        "ranges": [
+          [0.99, 1.0],
+          [0.0, 0.99]
+        ],
+        "coverage": 0.01,
+        "weights": [0.99, 0.01]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Ranges, partial coverage",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "configs",
+        "variations": [0, 1],
+        "ranges": [
+          [0, 0.1],
+          [0.9, 1.0]
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "Uses seed and hash version",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "key",
+        "seed": "foo",
+        "hashVersion": 2,
+        "variations": [0, 1],
+        "ranges": [
+          [0, 0.5],
+          [0.5, 1.0]
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Uses seed with default weights/coverage",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "key",
+        "seed": "foo",
+        "hashVersion": 2,
+        "variations": [0, 1]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Uses seed with weights/coverage",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "key",
+        "seed": "foo",
+        "hashVersion": 2,
+        "variations": [0, 1],
+        "weights": [0.5, 0.5],
+        "coverage": [0.99]
+      },
+      1,
+      true,
+      true
     ]
   ],
   "chooseVariation": [

--- a/spec/cases.json
+++ b/spec/cases.json
@@ -3270,7 +3270,7 @@
         "hashVersion": 2,
         "variations": [0, 1],
         "weights": [0.5, 0.5],
-        "coverage": [0.99]
+        "coverage": 0.99
       },
       1,
       true,

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -95,11 +95,13 @@ describe 'context' do
       gb.on? :feature1
 
       expect(gb.impressions["feature1"].to_json).to eq({
+        "bucket"=>0.154,
         "featureId" => "feature1",
         "hashAttribute" => "id",
         "hashValue" => "123",
         "inExperiment" => true,
         "hashUsed" => true,
+        "key"=>"0",
         "value" => 2,
         "variationId" => 0,
       })
@@ -110,11 +112,13 @@ describe 'context' do
           "variations" => [2, 3]
         },
         {
+          "bucket"=>0.154,
           "featureId" => "feature1",
           "hashAttribute" => "id",
           "hashValue" => "123",
           "inExperiment" => true,
           "hashUsed" => true,
+          "key"=>"0",
           "value" => 2,
           "variationId" => 0,
         }

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -15,10 +15,10 @@ end
 describe 'test suite' do
   describe 'hash' do
     test_cases['hash'].each do |test_case|
-      value, expected = test_case
+      seed, value, version, expected = test_case
 
       it value do
-        result = Growthbook::Util.hash(value)
+        result = Growthbook::Util.hash(seed: seed, value: value, version: version)
         expect(result.round(5)).to eq expected.round(5)
       end
     end


### PR DESCRIPTION
Support v0.4.0 spec, based on this https://github.com/growthbook/growthbook/pull/959 and the related docs to build your own SDK https://docs.growthbook.io/lib/build-your-own. These docs and the language agnostic `cases.json` file are really useful to maintain the SDKs up to date, congrats 👏 

While I attempted to only modify the required classes and methods to match the new specification, I believe there is room for improving the SDK. Specifically, I suggest:
- Adopting a more idiomatic Ruby and using a more standard style. [Rubocop](https://github.com/rubocop/rubocop) can help with this.
- Removing unnecessary code. Classes like `User`, `Experiment`, `ExperimentResult`, and some methods seem to no longer be required and can be cleaned up.
- Test the SDK with different Ruby versions.