### PR TITLE
Make `$in` and `$nin` work with arrays

### DIFF
--- a/lib/growthbook/conditions.rb
+++ b/lib/growthbook/conditions.rb
@@ -126,11 +126,9 @@ module Growthbook
           false
         end
       when '$in'
-        return false unless condition_value.is_a?(Array)
-        is_in?(attribute_value, condition_value)
+        in?(attribute_value, condition_value)
       when '$nin'
-        return false unless condition_value.is_a?(Array)
-        !is_in?(attribute_value, condition_value)
+        !in?(attribute_value, condition_value)
       when '$elemMatch'
         elem_match(condition_value, attribute_value)
       when '$size'
@@ -164,9 +162,10 @@ module Growthbook
       end
     end
 
-    def self.is_in?(actual, expected)
-      return expected.include?(actual) unless actual.is_a? Array
-        
+    def self.in?(actual, expected)
+      return false unless expected.is_a?(Array)
+      return expected.include?(actual) unless actual.is_a?(Array)
+
       (actual & expected).any?
     end
 

--- a/sig/lib/growthbook/conditions.rbs
+++ b/sig/lib/growthbook/conditions.rbs
@@ -25,6 +25,8 @@ module Growthbook
 
     def self.eval_operator_condition: (String operator, untyped attribute_value, untyped condition_value) -> bool
 
+    def self.in?: (untyped attribute_value, untyped condition_value) -> bool
+
     # Sets $VERBOSE for the duration of the block and back to its original
     # value afterwards. Used for testing invalid regexes.
     def self.silence_warnings: () { () -> untyped } -> untyped


### PR DESCRIPTION
https://github.com/growthbook/growthbook-ruby/pull/22 but fixing the existing style issues

Similar to https://github.com/growthbook/growthbook/pull/1246, trying to have the same behavior and the latest features in this SDK.