### PR TITLE
Various fixes …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,34 +2,6 @@ name: Build
 on:
   - push
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.2.2
-          bundler-cache: true
-      - name: Lint
-        run: |
-          gem install rubocop -v 1.50.2
-          gem install rubocop-rspec -v 2.20.0
-          gem install rubocop-performance -v 1.15
-          rubocop
-
-  type-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.1.1
-          bundler-cache: true
-      - name: RBS type checking with Steep
-        run: |
-          gem install steep -v 1.6.0
-          steep check --log-level=fatal
-
   build-test:
     runs-on: ubuntu-latest
     strategy:
@@ -38,11 +10,12 @@ jobs:
         ruby:
           - "2.5"
           - "3.2.2"
+          - "4.0"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Test
-        run: bundle exec rspec
+        run: bundle exec rake ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,10 +8,10 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.2
+          ruby-version: 4.0.0
           bundler-cache: true
       - name: Generate docs
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.2
+          ruby-version: 4.0.0
           bundler-cache: true
       - name: Publish gem
         uses: dawidd6/action-publish-gem@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,10 @@
-require:
+plugins:
   - rubocop-rspec
   - rubocop-performance
 
 AllCops:
   NewCops: enable
+  SuggestExtensions: false
   TargetRubyVersion: 2.5
 
 Lint:
@@ -31,6 +32,9 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Max: 100
 
+Layout/LeadingCommentSpace:
+  AllowRBSInlineAnnotation: true
+
 Layout/LineLength:
   Max: 200
 
@@ -39,6 +43,9 @@ Naming/VariableNumber:
 
 Naming/MethodParameterName:
   MinNameLength: 2
+
+Naming/PredicateMethod:
+  AllowedMethods: ['eval_and', 'eval_condition', 'eval_condition_value', 'eval_operator_condition', 'eval_or']
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_first_argument
@@ -74,6 +81,9 @@ RSpec/ExampleLength:
   Enabled: false
 
 RSpec/DescribeClass:
+  Enabled: false
+
+RSpec/LeakyLocalVariable:
   Enabled: false
 
 RSpec/NestedGroups:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,15 +14,11 @@ You can also run any of those tasks manually. See each section below.
 
 ## Testing
 
-Run unit tests with `bundler exec rspec`
+Run all tests and linters with `bundler exec rake ci`.
+
+Run only the tests with `bundler exec rspec`.
 
 ## Linting
-
-To use the linter, install it:
-
-    gem install rubocop -v 1.50.2
-    gem install rubocop-rspec -v 2.20.0
-    gem install rubocop-performance -v 1.15
 
 To auto-fix formatting, run the following:
 
@@ -43,10 +39,6 @@ If you use Visual Studio Code, you can use the extension [ruby-rubocop](https://
 The project uses RBS for type definitions and Steep for type checking.
 
 RBS comes preinstalled with Ruby version 3+.
-
-Install the required gem:
-
-    gem install steep -v 1.6.0
 
 You may find the following tools helpful:
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,16 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'rake', '~> 13.3'
+gem 'redcarpet', '~> 3.6'
+gem 'rspec', '~> 3.2'
+gem 'rspec-its', '~> 1.3'
+gem 'rubocop', '~> 1.84'
+gem 'rubocop-performance', '~> 1.26'
+gem 'rubocop-rspec', '~> 3.9'
+gem 'simplecov', '~> 0.21'
+gem 'simplecov-shields-badge', '~> 0.1.0'
+gem 'steep', '~> 1.10.0'
+gem 'webmock', '~> 3.18'
+gem 'yard', '~> 0.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,61 +2,237 @@ PATH
   remote: .
   specs:
     growthbook (1.3.0)
+      base64 (~> 0.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.4)
-      public_suffix (>= 2.0.2, < 6.0)
-    crack (0.4.5)
+    activesupport (8.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
+    base64 (0.3.0)
+    bigdecimal (4.0.1)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    crack (1.0.1)
+      bigdecimal
       rexml
-    diff-lcs (1.4.4)
-    docile (1.4.0)
-    hashdiff (1.0.1)
-    public_suffix (4.0.7)
-    rexml (3.2.5)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.0)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.0)
+    csv (3.3.5)
+    diff-lcs (1.6.2)
+    docile (1.4.1)
+    drb (2.2.3)
+    ffi (1.17.3)
+    ffi (1.17.3-arm64-darwin)
+    fileutils (1.8.0)
+    hashdiff (1.2.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    json (2.18.1)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    minitest (6.0.1)
+      prism (~> 1.5)
+    mutex_m (0.3.0)
+    parallel (1.27.0)
+    parser (3.3.10.1)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
+    public_suffix (7.0.2)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rbs (3.10.3)
+      logger
+      tsort
+    redcarpet (3.6.1)
+    regexp_parser (2.11.3)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-its (1.3.0)
+      rspec-support (~> 3.13.0)
+    rspec-its (1.3.1)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.10.0)
+    rspec-mocks (3.13.7)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.0)
-    simplecov (0.21.2)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    rubocop (1.84.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    rubocop-rspec (3.9.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.81)
+    ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
+    simplecov-html (0.13.2)
     simplecov-shields-badge (0.1.0)
       simplecov (~> 0.15)
-    simplecov_json_formatter (0.1.3)
-    webmock (3.18.1)
+    simplecov_json_formatter (0.1.4)
+    steep (1.10.0)
+      activesupport (>= 5.1)
+      concurrent-ruby (>= 1.1.10)
+      csv (>= 3.0.9)
+      fileutils (>= 1.1.0)
+      json (>= 2.1.0)
+      language_server-protocol (>= 3.17.0.4, < 4.0)
+      listen (~> 3.0)
+      logger (>= 1.3.0)
+      mutex_m (>= 0.3.0)
+      parser (>= 3.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (~> 3.9)
+      securerandom (>= 0.1)
+      strscan (>= 1.0.0)
+      terminal-table (>= 2, < 5)
+      uri (>= 0.12.0)
+    strscan (3.1.7)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
+    tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+    webmock (3.26.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    yard (0.9.38)
 
 PLATFORMS
-  arm64-darwin-22
-  x86_64-darwin-20
-  x86_64-darwin-21
-  x86_64-linux
+  arm64-darwin-24
+  ruby
 
 DEPENDENCIES
   growthbook!
+  rake (~> 13.3)
+  redcarpet (~> 3.6)
   rspec (~> 3.2)
   rspec-its (~> 1.3)
+  rubocop (~> 1.84)
+  rubocop-performance (~> 1.26)
+  rubocop-rspec (~> 3.9)
   simplecov (~> 0.21)
   simplecov-shields-badge (~> 0.1.0)
+  steep (~> 1.10.0)
   webmock (~> 3.18)
+  yard (~> 0.9)
+
+CHECKSUMS
+  activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
+  addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  ffi (1.17.3) sha256=0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c
+  ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
+  fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
+  growthbook (1.3.0)
+  hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  json (2.18.1) sha256=fe112755501b8d0466b5ada6cf50c8c3f41e897fa128ac5d263ec09eedc9f986
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (6.0.1) sha256=7854c74f48e2e975969062833adc4013f249a4b212f5e7b9d5c040bf838d54bb
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
+  parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
+  parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rbs (3.10.3) sha256=70627f3919016134d554e6c99195552ae3ef6020fe034c8e983facc9c192daa6
+  redcarpet (3.6.1) sha256=d444910e6aa55480c6bcdc0cdb057626e8a32c054c29e793fa642ba2f155f445
+  regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-its (1.3.1) sha256=c404314f933ffd5ef6e2cfa87167e272477a7007467db5ec59c96ad1679c51f6
+  rspec-mocks (3.13.7) sha256=0979034e64b1d7a838aaaddf12bf065ea4dc40ef3d4c39f01f93ae2c66c62b1c
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  rubocop (1.84.1) sha256=14cc626f355141f5a2ef53c10a68d66b13bb30639b26370a76559096cc6bcc1a
+  rubocop-ast (1.49.0) sha256=49c3676d3123a0923d333e20c6c2dbaaae2d2287b475273fddee0c61da9f71fd
+  rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
+  rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov-shields-badge (0.1.0) sha256=436321937a3929f016018a4a4c55865beb987b0d84871021308b8a0697937da4
+  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+  steep (1.10.0) sha256=1b295b55f9aaff1b8d3ee42453ee55bc2a1078fda0268f288edb2dc014f4d7d1
+  strscan (3.1.7) sha256=5f76462b94a3ea50b44973225b7d75b2cb96d4e1bee9ef1319b99ca117b72c8c
+  terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  webmock (3.26.1) sha256=4f696fb57c90a827c20aadb2d4f9058bbff10f7f043bd0d4c3f58791143b1cd7
+  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
 
 BUNDLED WITH
-   2.2.2
+  4.0.3

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@
 # Running `rake` runs all specified tasks in the list
 task default: %i[test type_check lint_fix doc]
 
+task ci: %i[test type_check lint]
+
 task :test do
   sh 'bundle', 'exec', 'rspec'
 end
@@ -11,12 +13,10 @@ task :type_check do
   sh 'steep', 'check', '--log-level=fatal'
 end
 
-# Requires that Rubocop is installed. See CONTRIBUTING.md for details.
 task :lint do
   sh 'rubocop'
 end
 
-# Requires that Rubocop is installed. See CONTRIBUTING.md for details.
 task :lint_fix do
   sh 'rubocop', '-A'
 end

--- a/growthbook.gemspec
+++ b/growthbook.gemspec
@@ -13,11 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.5.0'
 
-  s.add_development_dependency 'rspec', '~> 3.2'
-  s.add_development_dependency 'rspec-its', '~> 1.3'
-  s.add_development_dependency 'simplecov', '~> 0.21'
-  s.add_development_dependency 'simplecov-shields-badge', '~> 0.1.0'
-  s.add_development_dependency 'webmock', '~> 3.18'
+  s.add_dependency 'base64', '~> 0.3.0'
 
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/growthbook/conditions.rb
+++ b/lib/growthbook/conditions.rb
@@ -49,10 +49,9 @@ module Growthbook
     end
 
     def self.operator_object?(obj)
-      obj.each do |key, _value|
-        return false if key[0] != '$'
+      obj.each_key.all? do |key|
+        key[0] == '$'
       end
-      true
     end
 
     def self.get_type(attribute_value)
@@ -91,7 +90,7 @@ module Growthbook
       condition_value.to_json == attribute_value.to_json
     end
 
-    def self.elem_match(condition, attribute_value)
+    def self.elem_match?(condition, attribute_value)
       return false unless attribute_value.is_a? Array
 
       attribute_value.each do |item|
@@ -103,11 +102,13 @@ module Growthbook
       end
       false
     end
+    # alias for backwards compatibility
+    singleton_class.send(:alias_method, :elem_match, :elem_match?)
 
     def self.compare(val1, val2)
       if val1.is_a?(Numeric) || val2.is_a?(Numeric)
-        val1 = val1.is_a?(Numeric) ? val1 : val1.to_f
-        val2 = val2.is_a?(Numeric) ? val2 : val2.to_f
+        val1 = val1.to_f unless val1.is_a?(Numeric)
+        val2 = val2.to_f unless val2.is_a?(Numeric)
       end
 
       return 1 if val1 > val2
@@ -182,7 +183,7 @@ module Growthbook
 
         !in?(attribute_value, condition_value)
       when '$elemMatch'
-        elem_match(condition_value, attribute_value)
+        elem_match?(condition_value, attribute_value)
       when '$size'
         return false unless attribute_value.is_a? Array
 

--- a/lib/growthbook/context.rb
+++ b/lib/growthbook/context.rb
@@ -58,8 +58,8 @@ module Growthbook
       @impressions = {}
       @sticky_bucket_assignment_docs = {}
 
-      features = {}
-      attributes = {}
+      features = {} #: Hash[String, untyped]
+      attributes = {} #: Hash[String, untyped]
 
       options.transform_keys(&:to_sym).each do |key, value|
         case key
@@ -347,7 +347,7 @@ module Growthbook
         data = _generate_sticky_bucket_assignment_doc(hash_attribute, hash_value, assignment)
         doc = data['doc']
         if doc && data['changed']
-          @sticky_bucket_assignment_docs ||= {}
+          @sticky_bucket_assignment_docs ||= {} #: Hash[String, untyped]
           @sticky_bucket_assignment_docs[data['key']] = doc
           sticky_bucket_service.save_assignments(doc)
         end
@@ -361,7 +361,7 @@ module Growthbook
     end
 
     def stringify_keys(hash)
-      new_hash = {}
+      new_hash = {} #: Hash[String, untyped]
       hash.each do |key, value|
         new_hash[key.to_s] = value
       end
@@ -382,7 +382,7 @@ module Growthbook
       end
 
       hash_attribute, hash_value = get_hash_attribute(experiment.hash_attribute, experiment.fallback_attribute)
-      meta = experiment.meta ? experiment.meta[variation_index] : {}
+      meta = experiment.meta ? experiment.meta[variation_index] : {} #: Hash[String, untyped]
 
       result = Growthbook::InlineExperimentResult.new(
         {
@@ -503,7 +503,7 @@ module Growthbook
 
     def _derive_sticky_bucket_identifier_attributes
       attributes = Set.new
-      @features.each do |_key, feature|
+      @features.each_value do |feature|
         feature.rules.each do |rule|
           if rule.variations
             attributes.add(rule.hash_attribute || 'id')
@@ -515,7 +515,7 @@ module Growthbook
     end
 
     def _get_sticky_bucket_attributes
-      attributes = {}
+      attributes = {} #: Hash[String, untyped]
       @sticky_bucket_identifier_attributes = _derive_sticky_bucket_identifier_attributes if @using_derived_sticky_bucket_attributes
 
       return attributes unless @sticky_bucket_identifier_attributes
@@ -528,7 +528,7 @@ module Growthbook
     end
 
     def _get_sticky_bucket_assignments(attr = nil, fallback = nil)
-      merged = {}
+      merged = {} #: Hash[String, untyped]
 
       _, hash_value = get_hash_attribute(attr, nil)
       key = "#{attr}||#{hash_value}"
@@ -547,7 +547,7 @@ module Growthbook
       merged
     end
 
-    def _is_blocked(assignments, experiment_key, min_bucket_version)
+    def _blocked?(assignments, experiment_key, min_bucket_version)
       return false if min_bucket_version.zero?
 
       (0...min_bucket_version).each do |i|
@@ -560,12 +560,12 @@ module Growthbook
     def _get_sticky_bucket_variation(experiment_key, bucket_version = nil, min_bucket_version = nil, meta = nil, hash_attribute = nil, fallback_attribute = nil)
       bucket_version ||= 0
       min_bucket_version ||= 0
-      meta ||= []
+      meta ||= [] #: Array[Hash[String, untyped]]
 
       id = _get_sticky_bucket_experiment_key(experiment_key, bucket_version)
 
       assignments = _get_sticky_bucket_assignments(hash_attribute, fallback_attribute)
-      if _is_blocked(assignments, experiment_key, min_bucket_version)
+      if _blocked?(assignments, experiment_key, min_bucket_version)
         return {
           'variation'        => -1,
           'versionIsBlocked' => true
@@ -597,7 +597,7 @@ module Growthbook
 
     def _generate_sticky_bucket_assignment_doc(attribute_name, attribute_value, assignments)
       key = "#{attribute_name}||#{attribute_value}"
-      existing_assignments = @sticky_bucket_assignment_docs[key]&.fetch('assignments', {})
+      existing_assignments = @sticky_bucket_assignment_docs[key]&.fetch('assignments', nil) || {} #: Hash[String, untyped]
 
       if existing_assignments
         new_assignments = existing_assignments.merge(assignments)

--- a/lib/growthbook/feature.rb
+++ b/lib/growthbook/feature.rb
@@ -21,7 +21,7 @@ module Growthbook
     end
 
     def to_json(*_args)
-      res = {}
+      res = {} #: Hash[String, untyped]
       res['defaultValue'] = @default_value unless @default_value.nil?
       res['rules'] = []
       @rules.each do |rule|

--- a/lib/growthbook/feature_result.rb
+++ b/lib/growthbook/feature_result.rb
@@ -33,7 +33,6 @@ module Growthbook
       experiment,
       experiment_result
     )
-
       on = !value.nil? && value != 0 && value != '' && value != false
 
       @value = value
@@ -45,7 +44,7 @@ module Growthbook
     end
 
     def to_json(*_args)
-      json = {}
+      json = {} #: Hash[String, untyped]
       json['on'] = @on
       json['off'] = @off
       json['value'] = @value

--- a/lib/growthbook/fnv.rb
+++ b/lib/growthbook/fnv.rb
@@ -14,7 +14,7 @@ class FNV
     hash = INIT32
 
     data.bytes.each do |byte|
-      hash = hash ^ byte
+      hash ^= byte
       hash = (hash * PRIME32) % MOD32
     end
 

--- a/lib/growthbook/inline_experiment.rb
+++ b/lib/growthbook/inline_experiment.rb
@@ -95,7 +95,7 @@ module Growthbook
     end
 
     def to_json(*_args)
-      res = {}
+      res = {} #: Hash[String, untyped]
       res['key'] = @key
       res['variations'] = @variations
       res['weights'] = @weights unless @weights.nil?

--- a/lib/growthbook/sticky_bucket_service.rb
+++ b/lib/growthbook/sticky_bucket_service.rb
@@ -16,7 +16,7 @@ module Growthbook
     end
 
     def get_all_assignments(attributes)
-      docs = {}
+      docs = {} #: Hash[String, untyped]
       attributes.each do |attribute_name, attribute_value|
         doc = get_assignments(attribute_name, attribute_value)
         docs[get_key(attribute_name, attribute_value)] = doc if doc

--- a/lib/growthbook/util.rb
+++ b/lib/growthbook/util.rb
@@ -11,7 +11,7 @@ module Growthbook
       # Check if both strings are numeric so we can do natural ordering
       # for greater than / less than operators
       numeric = begin
-        (!Float(actual).nil? && !Float(desired).nil?)
+        !Float(actual).nil? && !Float(desired).nil?
       rescue StandardError
         false
       end
@@ -60,13 +60,9 @@ module Growthbook
     end
 
     def self.get_equal_weights(num_variations)
-      return [] if num_variations < 1
-
-      weights = []
-      (1..num_variations).each do |_i|
-        weights << (1.0 / num_variations)
+      (1..num_variations).map do
+        (1.0 / num_variations)
       end
-      weights
     end
 
     # Determine bucket ranges for experiment variations
@@ -85,7 +81,7 @@ module Growthbook
 
       # Convert weights to ranges
       cumulative = 0.0
-      ranges = []
+      ranges = [] #: Array[[Float, Float]]
       weights.each do |w|
         start = cumulative
         cumulative += w

--- a/sig/lib/growthbook/conditions.rbs
+++ b/sig/lib/growthbook/conditions.rbs
@@ -21,13 +21,15 @@ module Growthbook
 
     def self.eval_condition_value: (untyped condition_value, untyped attribute_value) -> bool
 
-    def self.elem_match: (Hash[String, untyped] condition, untyped attribute_value) -> bool
+    def self.elem_match?: (Hash[String, untyped] condition, untyped attribute_value) -> bool
 
     def self.eval_operator_condition: (String operator, untyped attribute_value, untyped condition_value) -> bool
 
     def self.in?: (untyped attribute_value, untyped condition_value) -> bool
 
     def self.compare: (untyped val1, untyped val2) -> Integer
+
+    def self.padded_version_string: (untyped input) -> String
 
     # Sets $VERBOSE for the duration of the block and back to its original
     # value afterwards. Used for testing invalid regexes.

--- a/sig/lib/growthbook/context.rbs
+++ b/sig/lib/growthbook/context.rbs
@@ -63,6 +63,24 @@ module Growthbook
 
     private
 
+    def _eval_prereqs: (untyped parent_conditions, Set[String] stack) -> String
+
+    def _derive_sticky_bucket_identifier_attributes: () -> Array[String]
+
+    def _get_sticky_bucket_attributes: () -> Hash[String, untyped]
+
+    def _get_sticky_bucket_assignments: (?String? attr, ?String? fallback) -> Hash[String, untyped]
+
+    def _blocked?: (Hash[String, untyped] assignments, String? experiment_key, Integer min_bucket_version) -> bool
+
+    def _get_sticky_bucket_variation: (String? experiment_key, ?Integer? bucket_version, ?Integer? min_bucket_version, ?untyped meta, ?String? hash_attribute, ?String? fallback_attribute) -> Hash[String, untyped]
+
+    def _get_sticky_bucket_experiment_key: (String? experiment_key, ?Integer? bucket_version) -> String
+
+    def refresh_sticky_buckets: (?force: bool) -> void
+
+    def _generate_sticky_bucket_assignment_doc: (String | Symbol attribute_name, untyped attribute_value, Hash[String, untyped] assignments) -> Hash[String, untyped]
+
     def _run: (InlineExperiment exp, ?::String | Symbol feature_id) -> InlineExperimentResult
 
     def stringify_keys: (Hash[String | Symbol, untyped] hash) -> Hash[String, untyped]


### PR DESCRIPTION
- add missing runtime dependency for recent rubies: base64
- add missing dev dependencies: rake, redcarpet, rubocop & plugins, steep, yard
- update dev dependencies to versions that run on recent rubies
- fix lint & type errors
- update & simplify CI setup