### PR TITLE
Update to spec 0.7.1 (ruleId, saved groups, case-insensitive operators, condition fixes)

### DIFF
--- a/lib/growthbook/conditions.rb
+++ b/lib/growthbook/conditions.rb
@@ -142,13 +142,13 @@ module Growthbook
         begin
           compare(attribute_value, condition_value).zero?
         rescue StandardError
-          false
+          attribute_value == condition_value
         end
       when '$ne'
         begin
           compare(attribute_value, condition_value) != 0
         rescue StandardError
-          false
+          attribute_value != condition_value
         end
       when '$lt'
         begin

--- a/lib/growthbook/conditions.rb
+++ b/lib/growthbook/conditions.rb
@@ -87,7 +87,7 @@ module Growthbook
       current
     end
 
-    def self.eval_condition_value(condition_value, attribute_value, saved_groups = {}, insensitive = false)
+    def self.eval_condition_value(condition_value, attribute_value, saved_groups = {}, insensitive: false)
       if condition_value.is_a?(Hash) && operator_object?(condition_value)
         condition_value.each do |key, value|
           return false unless eval_operator_condition(key, attribute_value, value, saved_groups)
@@ -124,56 +124,43 @@ module Growthbook
       0
     end
 
+    def self.eval_version_operator(operator, attribute_value, condition_value)
+      a = padded_version_string(attribute_value)
+      b = padded_version_string(condition_value)
+      case operator
+      when '$veq' then a == b
+      when '$vne' then a != b
+      when '$vgt' then a > b
+      when '$vgte' then a >= b
+      when '$vlt' then a < b
+      when '$vlte' then a <= b
+      end
+    end
+
+    def self.eval_compare_operator(operator, attribute_value, condition_value)
+      result = compare(attribute_value, condition_value)
+      case operator
+      when '$eq' then result.zero?
+      when '$ne' then result != 0
+      when '$lt' then result.negative?
+      when '$lte' then result <= 0
+      when '$gt' then result.positive?
+      when '$gte' then result >= 0
+      end
+    rescue StandardError
+      # Values weren't comparable (e.g. booleans); fall back to direct equality
+      return attribute_value == condition_value if operator == '$eq'
+      return attribute_value != condition_value if operator == '$ne'
+
+      false
+    end
+
     def self.eval_operator_condition(operator, attribute_value, condition_value, saved_groups = {})
       case operator
-      when '$veq'
-        padded_version_string(attribute_value) == padded_version_string(condition_value)
-      when '$vne'
-        padded_version_string(attribute_value) != padded_version_string(condition_value)
-      when '$vgt'
-        padded_version_string(attribute_value) > padded_version_string(condition_value)
-      when '$vgte'
-        padded_version_string(attribute_value) >= padded_version_string(condition_value)
-      when '$vlt'
-        padded_version_string(attribute_value) < padded_version_string(condition_value)
-      when '$vlte'
-        padded_version_string(attribute_value) <= padded_version_string(condition_value)
-      when '$eq'
-        begin
-          compare(attribute_value, condition_value).zero?
-        rescue StandardError
-          attribute_value == condition_value
-        end
-      when '$ne'
-        begin
-          compare(attribute_value, condition_value) != 0
-        rescue StandardError
-          attribute_value != condition_value
-        end
-      when '$lt'
-        begin
-          compare(attribute_value, condition_value).negative?
-        rescue StandardError
-          false
-        end
-      when '$lte'
-        begin
-          compare(attribute_value, condition_value) <= 0
-        rescue StandardError
-          false
-        end
-      when '$gt'
-        begin
-          compare(attribute_value, condition_value).positive?
-        rescue StandardError
-          false
-        end
-      when '$gte'
-        begin
-          compare(attribute_value, condition_value) >= 0
-        rescue StandardError
-          false
-        end
+      when '$veq', '$vne', '$vgt', '$vgte', '$vlt', '$vlte'
+        eval_version_operator(operator, attribute_value, condition_value)
+      when '$eq', '$ne', '$lt', '$lte', '$gt', '$gte'
+        eval_compare_operator(operator, attribute_value, condition_value)
       when '$regex'
         silence_warnings do
           re = Regexp.new(condition_value)
@@ -199,11 +186,11 @@ module Growthbook
       when '$ini'
         return false unless condition_value.is_a?(Array)
 
-        in?(attribute_value, condition_value, true)
+        in?(attribute_value, condition_value, insensitive: true)
       when '$nini'
         return false unless condition_value.is_a?(Array)
 
-        !in?(attribute_value, condition_value, true)
+        !in?(attribute_value, condition_value, insensitive: true)
       when '$inGroup'
         return false unless condition_value.is_a?(String)
         return false unless saved_groups.key?(condition_value)
@@ -246,7 +233,7 @@ module Growthbook
       return false unless attribute_value.is_a? Array
 
       condition_values.each do |cond|
-        passed = attribute_value.any? { |attr| eval_condition_value(cond, attr, saved_groups, insensitive) }
+        passed = attribute_value.any? { |attr| eval_condition_value(cond, attr, saved_groups, insensitive: insensitive) }
         return false unless passed
       end
       true
@@ -269,7 +256,7 @@ module Growthbook
       end.join('-')
     end
 
-    def self.in?(actual, expected, insensitive = false)
+    def self.in?(actual, expected, insensitive: false)
       expected ||= []
 
       if insensitive

--- a/lib/growthbook/conditions.rb
+++ b/lib/growthbook/conditions.rb
@@ -134,6 +134,7 @@ module Growthbook
       when '$vgte' then a >= b
       when '$vlt' then a < b
       when '$vlte' then a <= b
+      else false
       end
     end
 
@@ -146,6 +147,7 @@ module Growthbook
       when '$lte' then result <= 0
       when '$gt' then result.positive?
       when '$gte' then result >= 0
+      else false
       end
     rescue StandardError
       # Values weren't comparable (e.g. booleans); fall back to direct equality

--- a/lib/growthbook/conditions.rb
+++ b/lib/growthbook/conditions.rb
@@ -8,14 +8,20 @@ module Growthbook
   class Conditions
     # Evaluate a targeting conditions hash against an attributes hash
     # Both attributes and conditions only have string keys (no symbols)
-    def self.eval_condition(attributes, condition)
-      return eval_or(attributes, condition['$or']) if condition.key?('$or')
-      return !eval_or(attributes, condition['$nor']) if condition.key?('$nor')
-      return eval_and(attributes, condition['$and']) if condition.key?('$and')
-      return !eval_condition(attributes, condition['$not']) if condition.key?('$not')
-
+    def self.eval_condition(attributes, condition, saved_groups = {})
       condition.each do |key, value|
-        return false unless eval_condition_value(value, get_path(attributes, key))
+        case key
+        when '$or'
+          return false unless eval_or(attributes, value, saved_groups)
+        when '$nor'
+          return false if eval_or(attributes, value, saved_groups)
+        when '$and'
+          return false unless eval_and(attributes, value, saved_groups)
+        when '$not'
+          return false if eval_condition(attributes, value, saved_groups)
+        else
+          return false unless eval_condition_value(value, get_path(attributes, key), saved_groups)
+        end
       end
 
       true
@@ -32,18 +38,18 @@ module Growthbook
       condition
     end
 
-    def self.eval_or(attributes, conditions)
+    def self.eval_or(attributes, conditions, saved_groups = {})
       return true if conditions.length <= 0
 
       conditions.each do |condition|
-        return true if eval_condition(attributes, condition)
+        return true if eval_condition(attributes, condition, saved_groups)
       end
       false
     end
 
-    def self.eval_and(attributes, conditions)
+    def self.eval_and(attributes, conditions, saved_groups = {})
       conditions.each do |condition|
-        return false unless eval_condition(attributes, condition)
+        return false unless eval_condition(attributes, condition, saved_groups)
       end
       true
     end
@@ -81,23 +87,25 @@ module Growthbook
       current
     end
 
-    def self.eval_condition_value(condition_value, attribute_value)
+    def self.eval_condition_value(condition_value, attribute_value, saved_groups = {}, insensitive = false)
       if condition_value.is_a?(Hash) && operator_object?(condition_value)
         condition_value.each do |key, value|
-          return false unless eval_operator_condition(key, attribute_value, value)
+          return false unless eval_operator_condition(key, attribute_value, value, saved_groups)
         end
         return true
       end
+      return condition_value.downcase == attribute_value.downcase if insensitive && condition_value.is_a?(String) && attribute_value.is_a?(String)
+
       condition_value.to_json == attribute_value.to_json
     end
 
-    def self.elem_match(condition, attribute_value)
+    def self.elem_match(condition, attribute_value, saved_groups = {})
       return false unless attribute_value.is_a? Array
 
       attribute_value.each do |item|
         if operator_object?(condition)
-          return true if eval_condition_value(condition, item)
-        elsif eval_condition(item, condition)
+          return true if eval_condition_value(condition, item, saved_groups)
+        elsif eval_condition(item, condition, saved_groups)
           return true
         end
       end
@@ -116,7 +124,7 @@ module Growthbook
       0
     end
 
-    def self.eval_operator_condition(operator, attribute_value, condition_value)
+    def self.eval_operator_condition(operator, attribute_value, condition_value, saved_groups = {})
       case operator
       when '$veq'
         padded_version_string(attribute_value) == padded_version_string(condition_value)
@@ -173,6 +181,13 @@ module Growthbook
         rescue StandardError
           false
         end
+      when '$regexi'
+        silence_warnings do
+          re = Regexp.new(condition_value, Regexp::IGNORECASE)
+          !!attribute_value.match(re)
+        rescue StandardError
+          false
+        end
       when '$in'
         return false unless condition_value.is_a?(Array)
 
@@ -181,23 +196,36 @@ module Growthbook
         return false unless condition_value.is_a?(Array)
 
         !in?(attribute_value, condition_value)
+      when '$ini'
+        return false unless condition_value.is_a?(Array)
+
+        in?(attribute_value, condition_value, true)
+      when '$nini'
+        return false unless condition_value.is_a?(Array)
+
+        !in?(attribute_value, condition_value, true)
+      when '$inGroup'
+        return false unless condition_value.is_a?(String)
+        return false unless saved_groups.key?(condition_value)
+
+        in?(attribute_value, saved_groups[condition_value] || [])
+      when '$notInGroup'
+        return false unless condition_value.is_a?(String)
+        return true unless saved_groups.key?(condition_value)
+
+        !in?(attribute_value, saved_groups[condition_value] || [])
       when '$elemMatch'
-        elem_match(condition_value, attribute_value)
+        elem_match(condition_value, attribute_value, saved_groups)
       when '$size'
         return false unless attribute_value.is_a? Array
 
-        eval_condition_value(condition_value, attribute_value.length)
+        eval_condition_value(condition_value, attribute_value.length, saved_groups)
       when '$all'
-        return false unless attribute_value.is_a? Array
+        in_all?(condition_value, attribute_value, saved_groups, false)
+      when '$alli'
+        return false unless condition_value.is_a?(Array)
 
-        condition_value.each do |condition|
-          passed = false
-          attribute_value.each do |attr|
-            passed = true if eval_condition_value(condition, attr)
-          end
-          return false unless passed
-        end
-        true
+        in_all?(condition_value, attribute_value, saved_groups, true)
       when '$exists'
         exists = !attribute_value.nil?
         if condition_value
@@ -208,10 +236,20 @@ module Growthbook
       when '$type'
         condition_value == get_type(attribute_value)
       when '$not'
-        !eval_condition_value(condition_value, attribute_value)
+        !eval_condition_value(condition_value, attribute_value, saved_groups)
       else
         false
       end
+    end
+
+    def self.in_all?(condition_values, attribute_value, saved_groups, insensitive)
+      return false unless attribute_value.is_a? Array
+
+      condition_values.each do |cond|
+        passed = attribute_value.any? { |attr| eval_condition_value(cond, attr, saved_groups, insensitive) }
+        return false unless passed
+      end
+      true
     end
 
     def self.padded_version_string(input)
@@ -231,7 +269,17 @@ module Growthbook
       end.join('-')
     end
 
-    def self.in?(actual, expected)
+    def self.in?(actual, expected, insensitive = false)
+      expected ||= []
+
+      if insensitive
+        fold = ->(val) { val.is_a?(String) ? val.downcase : val }
+        folded_expected = expected.map { |exp| fold.call(exp) }
+        return actual.any? { |el| folded_expected.include?(fold.call(el)) } if actual.is_a?(Array)
+
+        return folded_expected.include?(fold.call(actual))
+      end
+
       return expected.include?(actual) unless actual.is_a?(Array)
 
       (actual & expected).any?

--- a/lib/growthbook/conditions.rb
+++ b/lib/growthbook/conditions.rb
@@ -94,7 +94,7 @@ module Growthbook
         end
         return true
       end
-      return condition_value.downcase == attribute_value.downcase if insensitive && condition_value.is_a?(String) && attribute_value.is_a?(String)
+      return condition_value.casecmp?(attribute_value) if insensitive && condition_value.is_a?(String) && attribute_value.is_a?(String)
 
       condition_value.to_json == attribute_value.to_json
     end

--- a/lib/growthbook/context.rb
+++ b/lib/growthbook/context.rb
@@ -35,6 +35,9 @@ module Growthbook
     # @return [Hash[String, Any]] Forced feature values
     attr_reader :forced_features
 
+    # @return [Hash[String, Array]] Saved groups, used by the $inGroup/$notInGroup operators
+    attr_reader :saved_groups
+
     # @return [Growthbook::StickyBucketService] Sticky bucket service for sticky bucketing
     attr_reader :sticky_bucket_service
 
@@ -59,6 +62,7 @@ module Growthbook
       @enabled = true
       @impressions = {}
       @sticky_bucket_assignment_docs = {}
+      @saved_groups = {}
 
       features = {}
       attributes = {}
@@ -92,6 +96,8 @@ module Growthbook
           @sticky_bucket_service = value
         when :sticky_bucket_identifier_attributes
           @sticky_bucket_identifier_attributes = value
+        when :saved_groups, :savedGroups
+          @saved_groups = value || {}
         else
           warn("Unknown context option: #{key}")
         end
@@ -160,7 +166,7 @@ module Growthbook
 
         return 'cyclic' if parent_res.source == 'cyclicPrerequisite'
 
-        next if Growthbook::Conditions.eval_condition({ 'value' => parent_res.value }, parent_condition['condition'])
+        next if Growthbook::Conditions.eval_condition({ 'value' => parent_res.value }, parent_condition['condition'], @saved_groups)
         return 'gate' if parent_condition['gate']
 
         return 'fail'
@@ -373,7 +379,7 @@ module Growthbook
     def condition_passes?(condition)
       return false if condition.nil?
 
-      Growthbook::Conditions.eval_condition(@attributes, condition)
+      Growthbook::Conditions.eval_condition(@attributes, condition, @saved_groups)
     end
 
     def get_experiment_result(experiment, variation_index = -1, hash_used: false, feature_id: '', bucket: nil, sticky_bucket_used: false)

--- a/lib/growthbook/context.rb
+++ b/lib/growthbook/context.rb
@@ -184,6 +184,9 @@ module Growthbook
 
       return get_feature_result(key.to_s, nil, 'cyclicPrerequisite', nil, nil) if stack.include?(key.to_s)
 
+      # Work on a copy so sibling prerequisite evaluations don't pollute each
+      # other's path (matches the by-value stack semantics of the other SDKs)
+      stack = stack.dup
       stack.add(key.to_s)
 
       feature.rules.each do |rule|
@@ -467,6 +470,7 @@ module Growthbook
 
     def included_in_rollout?(seed:, hash_attribute:, fallback_attribute:, hash_version:, range:, coverage:)
       return true if range.nil? && coverage.nil?
+      return false if range.nil? && coverage == 0
 
       _, hash_value_raw = get_hash_attribute(hash_attribute, fallback_attribute)
 

--- a/lib/growthbook/context.rb
+++ b/lib/growthbook/context.rb
@@ -214,7 +214,7 @@ module Growthbook
           )
           next unless included_in_rollout
 
-          return get_feature_result(key.to_s, rule.force, 'force', nil, nil)
+          return get_feature_result(key.to_s, rule.force, 'force', nil, nil, rule.id)
         end
         # Experiment rule
         next unless rule.experiment?
@@ -226,7 +226,7 @@ module Growthbook
 
         next unless result.in_experiment && !result.passthrough
 
-        return get_feature_result(key.to_s, result.value, 'experiment', exp, result)
+        return get_feature_result(key.to_s, result.value, 'experiment', exp, result, rule.id)
       end
 
       # Fallback
@@ -407,8 +407,8 @@ module Growthbook
       result
     end
 
-    def get_feature_result(key, value, source, experiment, experiment_result)
-      res = Growthbook::FeatureResult.new(value, source, experiment, experiment_result)
+    def get_feature_result(key, value, source, experiment, experiment_result, rule_id = '')
+      res = Growthbook::FeatureResult.new(value, source, experiment, experiment_result, rule_id)
 
       track_feature_usage(key, res)
 

--- a/lib/growthbook/context.rb
+++ b/lib/growthbook/context.rb
@@ -470,7 +470,7 @@ module Growthbook
 
     def included_in_rollout?(seed:, hash_attribute:, fallback_attribute:, hash_version:, range:, coverage:)
       return true if range.nil? && coverage.nil?
-      return false if range.nil? && coverage == 0
+      return false if range.nil? && coverage&.zero?
 
       _, hash_value_raw = get_hash_attribute(hash_attribute, fallback_attribute)
 

--- a/lib/growthbook/feature_result.rb
+++ b/lib/growthbook/feature_result.rb
@@ -27,11 +27,16 @@ module Growthbook
     # @return [Growthbook::InlineExperimentResult, nil]
     attr_reader :experiment_result
 
+    # The id of the rule (if any) that was used to assign the value
+    # @return [String]
+    attr_reader :rule_id
+
     def initialize(
       value,
       source,
       experiment,
-      experiment_result
+      experiment_result,
+      rule_id = ''
     )
 
       on = !value.nil? && value != 0 && value != '' && value != false
@@ -42,6 +47,7 @@ module Growthbook
       @source = source
       @experiment = experiment
       @experiment_result = experiment_result
+      @rule_id = rule_id || ''
     end
 
     def to_json(*_args)
@@ -50,6 +56,7 @@ module Growthbook
       json['off'] = @off
       json['value'] = @value
       json['source'] = @source
+      json['ruleId'] = @rule_id
 
       if @experiment
         json['experiment'] = @experiment.to_json

--- a/lib/growthbook/feature_rule.rb
+++ b/lib/growthbook/feature_rule.rb
@@ -3,6 +3,9 @@
 module Growthbook
   # Internal class that overrides the default value of a Feature based on a set of requirements.
   class FeatureRule
+    # @return [String , nil] Unique identifier for this rule
+    attr_reader :id
+
     # @return [Hash , nil] Optional targeting condition
     attr_reader :condition
 
@@ -70,6 +73,7 @@ module Growthbook
     attr_accessor :parent_conditions
 
     def initialize(rule)
+      @id = get_option(rule, :id)
       @coverage = get_option(rule, :coverage)
       @force = get_option(rule, :force)
       @variations = get_option(rule, :variations)

--- a/sig/lib/growthbook/conditions.rbs
+++ b/sig/lib/growthbook/conditions.rbs
@@ -4,14 +4,14 @@ module Growthbook
   class Conditions
     # Evaluate a targeting conditions hash against an attributes hash
     # Both attributes and conditions only have string keys (no symbols)
-    def self.eval_condition: (Hash[String, untyped] attributes, Hash[String, untyped] condition) -> bool
+    def self.eval_condition: (Hash[String, untyped] attributes, Hash[String, untyped] condition, ?Hash[String, untyped] saved_groups) -> bool
 
     # Helper function to ensure conditions only have string keys (no symbols)
     def self.parse_condition: (Hash[untyped, untyped] condition) -> (untyped)
 
-    def self.eval_or: (Hash[String, untyped] attributes, Array[Hash[String, untyped]] conditions) -> (bool)
+    def self.eval_or: (Hash[String, untyped] attributes, Array[Hash[String, untyped]] conditions, ?Hash[String, untyped] saved_groups) -> (bool)
 
-    def self.eval_and: (Hash[String, untyped] attributes, Array[Hash[String, untyped]] conditions) -> (bool)
+    def self.eval_and: (Hash[String, untyped] attributes, Array[Hash[String, untyped]] conditions, ?Hash[String, untyped] saved_groups) -> (bool)
 
     def self.operator_object?: (Hash[String, untyped] obj) -> bool
 
@@ -19,13 +19,15 @@ module Growthbook
 
     def self.get_path: (Hash[String, untyped]? attributes, String path) -> (nil | untyped)
 
-    def self.eval_condition_value: (untyped condition_value, untyped attribute_value) -> bool
+    def self.eval_condition_value: (untyped condition_value, untyped attribute_value, ?Hash[String, untyped] saved_groups, ?bool insensitive) -> bool
 
-    def self.elem_match: (Hash[String, untyped] condition, untyped attribute_value) -> bool
+    def self.elem_match: (Hash[String, untyped] condition, untyped attribute_value, ?Hash[String, untyped] saved_groups) -> bool
 
-    def self.eval_operator_condition: (String operator, untyped attribute_value, untyped condition_value) -> bool
+    def self.eval_operator_condition: (String operator, untyped attribute_value, untyped condition_value, ?Hash[String, untyped] saved_groups) -> bool
 
-    def self.in?: (untyped attribute_value, untyped condition_value) -> bool
+    def self.in_all?: (Array[untyped] condition_values, untyped attribute_value, Hash[String, untyped] saved_groups, bool insensitive) -> bool
+
+    def self.in?: (untyped attribute_value, untyped condition_value, ?bool insensitive) -> bool
 
     def self.compare: (untyped val1, untyped val2) -> Integer
 

--- a/sig/lib/growthbook/conditions.rbs
+++ b/sig/lib/growthbook/conditions.rbs
@@ -19,15 +19,19 @@ module Growthbook
 
     def self.get_path: (Hash[String, untyped]? attributes, String path) -> (nil | untyped)
 
-    def self.eval_condition_value: (untyped condition_value, untyped attribute_value, ?Hash[String, untyped] saved_groups, ?bool insensitive) -> bool
+    def self.eval_condition_value: (untyped condition_value, untyped attribute_value, ?Hash[String, untyped] saved_groups, ?insensitive: bool) -> bool
 
     def self.elem_match: (Hash[String, untyped] condition, untyped attribute_value, ?Hash[String, untyped] saved_groups) -> bool
+
+    def self.eval_version_operator: (String operator, untyped attribute_value, untyped condition_value) -> bool
+
+    def self.eval_compare_operator: (String operator, untyped attribute_value, untyped condition_value) -> bool
 
     def self.eval_operator_condition: (String operator, untyped attribute_value, untyped condition_value, ?Hash[String, untyped] saved_groups) -> bool
 
     def self.in_all?: (Array[untyped] condition_values, untyped attribute_value, Hash[String, untyped] saved_groups, bool insensitive) -> bool
 
-    def self.in?: (untyped attribute_value, untyped condition_value, ?bool insensitive) -> bool
+    def self.in?: (untyped attribute_value, untyped condition_value, ?insensitive: bool) -> bool
 
     def self.compare: (untyped val1, untyped val2) -> Integer
 

--- a/sig/lib/growthbook/context.rbs
+++ b/sig/lib/growthbook/context.rbs
@@ -73,7 +73,7 @@ module Growthbook
 
     def get_experiment_result: (InlineExperiment experiment, ?::Integer variation_index, ?hash_used: bool, ?sticky_bucket_used: bool, ?feature_id: ::String | Symbol, ?bucket: Float?) -> InlineExperimentResult
 
-    def get_feature_result: (String, untyped, ::String, InlineExperiment?, InlineExperimentResult?, ?::String rule_id) -> FeatureResult
+    def get_feature_result: (String, untyped, ::String, InlineExperiment?, InlineExperimentResult?, ?(::String | nil) rule_id) -> FeatureResult
 
     def get_feature: (String | Symbol key) -> (Feature | nil)
 

--- a/sig/lib/growthbook/context.rbs
+++ b/sig/lib/growthbook/context.rbs
@@ -29,6 +29,8 @@ module Growthbook
 
     attr_reader forced_features: Hash[String | Symbol, untyped]
 
+    attr_reader saved_groups: Hash[String, untyped]
+
     attr_reader sticky_bucket_service: Growthbook::StickyBucketService
 
     attr_reader sticky_bucket_identifier_attributes: Array[String]
@@ -71,7 +73,7 @@ module Growthbook
 
     def get_experiment_result: (InlineExperiment experiment, ?::Integer variation_index, ?hash_used: bool, ?sticky_bucket_used: bool, ?feature_id: ::String | Symbol, ?bucket: Float?) -> InlineExperimentResult
 
-    def get_feature_result: (String, untyped, ::String, InlineExperiment?, InlineExperimentResult?) -> FeatureResult
+    def get_feature_result: (String, untyped, ::String, InlineExperiment?, InlineExperimentResult?, ?::String rule_id) -> FeatureResult
 
     def get_feature: (String | Symbol key) -> (Feature | nil)
 

--- a/sig/lib/growthbook/feature_result.rbs
+++ b/sig/lib/growthbook/feature_result.rbs
@@ -25,7 +25,11 @@ module Growthbook
     # @return [Growthbook::InlineExperimentResult, nil]
     attr_reader experiment_result: InlineExperimentResult?
 
-    def initialize: (untyped value, String source, (InlineExperiment | nil) experiment, (InlineExperimentResult | nil) experiment_result) -> void
+    # The id of the rule (if any) that was used to assign the value
+    # @return [String]
+    attr_reader rule_id: String
+
+    def initialize: (untyped value, String source, (InlineExperiment | nil) experiment, (InlineExperimentResult | nil) experiment_result, ?String rule_id) -> void
 
     def to_json: (*untyped _args) -> Hash[String, untyped]
   end

--- a/sig/lib/growthbook/feature_result.rbs
+++ b/sig/lib/growthbook/feature_result.rbs
@@ -29,7 +29,7 @@ module Growthbook
     # @return [String]
     attr_reader rule_id: String
 
-    def initialize: (untyped value, String source, (InlineExperiment | nil) experiment, (InlineExperimentResult | nil) experiment_result, ?String rule_id) -> void
+    def initialize: (untyped value, String source, (InlineExperiment | nil) experiment, (InlineExperimentResult | nil) experiment_result, ?(String | nil) rule_id) -> void
 
     def to_json: (*untyped _args) -> Hash[String, untyped]
   end

--- a/sig/lib/growthbook/feature_rule.rbs
+++ b/sig/lib/growthbook/feature_rule.rbs
@@ -1,6 +1,9 @@
 module Growthbook
   # Internal class that overrides the default value of a Feature based on a set of requirements.
   class FeatureRule
+    # @return [String , nil] Unique identifier for this rule
+    attr_reader id: String?
+
     # @return [Hash , nil] Optional targeting condition
     attr_reader condition: (Hash[String, untyped])
     # attr_reader condition: (Hash[String, untyped] | Array[untyped])

--- a/spec/cases.json
+++ b/spec/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.5.4",
+  "specVersion": "0.7.1",
   "evalCondition": [
     [
       "$not - pass",
@@ -482,6 +482,18 @@
       false
     ],
     [
+      "$in - fail (case sensitive mismatch)",
+      {
+        "country": {
+          "$in": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      false
+    ],
+    [
       "$nin - pass",
       {
         "num": {
@@ -576,6 +588,198 @@
         "tags": []
       },
       true
+    ],
+    [
+      "$nin - pass (case sensitive mismatch)",
+      {
+        "country": {
+          "$nin": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - pass (case insensitive match)",
+      {
+        "country": {
+          "$ini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - pass (uppercase pattern, lowercase value)",
+      {
+        "country": {
+          "$ini": ["US", "UK"]
+        }
+      },
+      {
+        "country": "us"
+      },
+      true
+    ],
+    [
+      "$ini - pass (mixed case)",
+      {
+        "country": {
+          "$ini": ["Us", "Uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - fail (no match)",
+      {
+        "country": {
+          "$ini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "CA"
+      },
+      false
+    ],
+    [
+      "$ini - array pass 1",
+      {
+        "tags": {
+          "$ini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "A"]
+      },
+      true
+    ],
+    [
+      "$ini - array pass 2",
+      {
+        "tags": {
+          "$ini": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["d", "b", "f"]
+      },
+      true
+    ],
+    [
+      "$ini - array fail",
+      {
+        "tags": {
+          "$ini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "f"]
+      },
+      false
+    ],
+    [
+      "$ini - not array",
+      {
+        "num": {
+          "$ini": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
+    ],
+    [
+      "$nini - pass (case insensitive match)",
+      {
+        "country": {
+          "$nini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "CA"
+      },
+      true
+    ],
+    [
+      "$nini - fail (case insensitive match)",
+      {
+        "country": {
+          "$nini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      false
+    ],
+    [
+      "$nini - fail (uppercase pattern, lowercase value)",
+      {
+        "country": {
+          "$nini": ["US", "UK"]
+        }
+      },
+      {
+        "country": "us"
+      },
+      false
+    ],
+    [
+      "$nini - array pass",
+      {
+        "tags": {
+          "$nini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "f"]
+      },
+      true
+    ],
+    [
+      "$nini - array fail 1",
+      {
+        "tags": {
+          "$nini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "A"]
+      },
+      false
+    ],
+    [
+      "$nini - array fail 2",
+      {
+        "tags": {
+          "$nini": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["d", "b", "f"]
+      },
+      false
+    ],
+    [
+      "$nini - not array",
+      {
+        "num": {
+          "$nini": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
     ],
     [
       "$elemMatch - pass - flat arrays",
@@ -750,6 +954,54 @@
       {
         "userAgent": {
           "$regex": "(Mobile|Tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      false
+    ],
+    [
+      "$regex - fail (case sensitive mismatch)",
+      {
+        "userAgent": {
+          "$regex": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      false
+    ],
+    [
+      "$regexi - pass (case insensitive match)",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      true
+    ],
+    [
+      "$regexi - pass (uppercase pattern, lowercase value)",
+      {
+        "userAgent": {
+          "$regexi": "(MOBILE|TABLET)"
+        }
+      },
+      {
+        "userAgent": "android mobile browser"
+      },
+      true
+    ],
+    [
+      "$regexi - fail",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
         }
       },
       {
@@ -1443,6 +1695,78 @@
       false
     ],
     [
+      "$all - fail (case sensitive mismatch)",
+      {
+        "tags": {
+          "$all": ["one", "three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "THREE"]
+      },
+      false
+    ],
+    [
+      "$alli - pass (case insensitive match)",
+      {
+        "tags": {
+          "$alli": ["one", "three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "THREE"]
+      },
+      true
+    ],
+    [
+      "$alli - pass (uppercase pattern, lowercase value)",
+      {
+        "tags": {
+          "$alli": ["ONE", "THREE"]
+        }
+      },
+      {
+        "tags": ["one", "two", "three"]
+      },
+      true
+    ],
+    [
+      "$alli - pass (mixed case)",
+      {
+        "tags": {
+          "$alli": ["One", "Three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "three"]
+      },
+      true
+    ],
+    [
+      "$alli - fail (case insensitive, missing value)",
+      {
+        "tags": {
+          "$alli": ["one", "three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "four"]
+      },
+      false
+    ],
+    [
+      "$alli - fail not array",
+      {
+        "tags": {
+          "$alli": ["one", "three"]
+        }
+      },
+      {
+        "tags": "hello"
+      },
+      false
+    ],
+    [
       "$nor - pass",
       {
         "$nor": [
@@ -1671,6 +1995,32 @@
       {
         "userId": ""
       },
+      false
+    ],
+    [
+      "null condition - false attribute",
+      {
+        "userId": null
+      },
+      {
+        "userId": false
+      },
+      false
+    ],
+    [
+      "false condition - missing attribute",
+      {
+        "userId": false
+      },
+      {},
+      false
+    ],
+    [
+      "false strict condition - missing attribute",
+      {
+        "userId": { "$eq": false }
+      },
+      {},
       false
     ],
     [
@@ -2019,79 +2369,889 @@
         "v": "1.2.3-alpha"
       },
       true
+    ],
+    [
+      "version 0.9.99 < 1.0.0",
+      {
+        "version": {
+          "$vlt": "1.0.0"
+        }
+      },
+      {
+        "version": "0.9.99"
+      },
+      true
+    ],
+    [
+      "version 0.9.0 < 0.10.0",
+      {
+        "version": {
+          "$vlt": "0.10.0"
+        }
+      },
+      {
+        "version": "0.9.0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-0.0 < 1.0.0-0.0.0",
+      {
+        "version": {
+          "$vlt": "1.0.0-0.0.0"
+        }
+      },
+      {
+        "version": "1.0.0-0.0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-9999 < 1.0.0--",
+      {
+        "version": {
+          "$vlt": "1.0.0--"
+        }
+      },
+      {
+        "version": "1.0.0-9999"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-99 < 1.0.0-100",
+      {
+        "version": {
+          "$vlt": "1.0.0-100"
+        }
+      },
+      {
+        "version": "1.0.0-99"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-alpha < 1.0.0-alpha.1",
+      {
+        "version": {
+          "$vlt": "1.0.0-alpha.1"
+        }
+      },
+      {
+        "version": "1.0.0-alpha"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-alpha.1 < 1.0.0-alpha.beta",
+      {
+        "version": {
+          "$vlt": "1.0.0-alpha.beta"
+        }
+      },
+      {
+        "version": "1.0.0-alpha.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-alpha.beta < 1.0.0-beta",
+      {
+        "version": {
+          "$vlt": "1.0.0-beta"
+        }
+      },
+      {
+        "version": "1.0.0-alpha.beta"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-beta < 1.0.0-beta.2",
+      {
+        "version": {
+          "$vlt": "1.0.0-beta.2"
+        }
+      },
+      {
+        "version": "1.0.0-beta"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-beta.2 < 1.0.0-beta.11",
+      {
+        "version": {
+          "$vlt": "1.0.0-beta.11"
+        }
+      },
+      {
+        "version": "1.0.0-beta.2"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-beta.11 < 1.0.0-rc.1",
+      {
+        "version": {
+          "$vlt": "1.0.0-rc.1"
+        }
+      },
+      {
+        "version": "1.0.0-beta.11"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-rc.1 < 1.0.0",
+      {
+        "version": {
+          "$vlt": "1.0.0"
+        }
+      },
+      {
+        "version": "1.0.0-rc.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-0 < 1.0.0--1",
+      {
+        "version": {
+          "$vlt": "1.0.0--1"
+        }
+      },
+      {
+        "version": "1.0.0-0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-0 < 1.0.0-1",
+      {
+        "version": {
+          "$vlt": "1.0.0-1"
+        }
+      },
+      {
+        "version": "1.0.0-0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-1.0 < 1.0.0-1.-1",
+      {
+        "version": {
+          "$vlt": "1.0.0-1.-1"
+        }
+      },
+      {
+        "version": "1.0.0-1.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b.c < 1.2.3-a.b.c.d",
+      {
+        "version": {
+          "$vlt": "1.2.3-a.b.c.d"
+        }
+      },
+      {
+        "version": "1.2.3-a.b.c"
+      },
+      true
+    ],
+    [
+      "version 0.0.0 > 0.0.0-foo",
+      {
+        "version": {
+          "$vgt": "0.0.0-foo"
+        }
+      },
+      {
+        "version": "0.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.0.1 > 0.0.0",
+      {
+        "version": {
+          "$vgt": "0.0.0"
+        }
+      },
+      {
+        "version": "0.0.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0 > 0.9.9",
+      {
+        "version": {
+          "$vgt": "0.9.9"
+        }
+      },
+      {
+        "version": "1.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.10.0 > 0.9.0",
+      {
+        "version": {
+          "$vgt": "0.9.0"
+        }
+      },
+      {
+        "version": "0.10.0"
+      },
+      true
+    ],
+    [
+      "version 0.99.0 > 0.10.0",
+      {
+        "version": {
+          "$vgt": "0.10.0"
+        }
+      },
+      {
+        "version": "0.99.0"
+      },
+      true
+    ],
+    [
+      "version 2.0.0 > 1.2.3",
+      {
+        "version": {
+          "$vgt": "1.2.3"
+        }
+      },
+      {
+        "version": "2.0.0"
+      },
+      true
+    ],
+    [
+      "version v0.0.0 > 0.0.0-foo",
+      {
+        "version": {
+          "$vgt": "0.0.0-foo"
+        }
+      },
+      {
+        "version": "v0.0.0"
+      },
+      true
+    ],
+    [
+      "version v0.0.1 > 0.0.0",
+      {
+        "version": {
+          "$vgt": "0.0.0"
+        }
+      },
+      {
+        "version": "v0.0.1"
+      },
+      true
+    ],
+    [
+      "version v1.0.0 > 0.9.9",
+      {
+        "version": {
+          "$vgt": "0.9.9"
+        }
+      },
+      {
+        "version": "v1.0.0"
+      },
+      true
+    ],
+    [
+      "version v0.10.0 > 0.9.0",
+      {
+        "version": {
+          "$vgt": "0.9.0"
+        }
+      },
+      {
+        "version": "v0.10.0"
+      },
+      true
+    ],
+    [
+      "version v0.99.0 > 0.10.0",
+      {
+        "version": {
+          "$vgt": "0.10.0"
+        }
+      },
+      {
+        "version": "v0.99.0"
+      },
+      true
+    ],
+    [
+      "version v2.0.0 > 1.2.3",
+      {
+        "version": {
+          "$vgt": "1.2.3"
+        }
+      },
+      {
+        "version": "v2.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.0.0 > v0.0.0-foo",
+      {
+        "version": {
+          "$vgt": "v0.0.0-foo"
+        }
+      },
+      {
+        "version": "0.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.0.1 > v0.0.0",
+      {
+        "version": {
+          "$vgt": "v0.0.0"
+        }
+      },
+      {
+        "version": "0.0.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0 > v0.9.9",
+      {
+        "version": {
+          "$vgt": "v0.9.9"
+        }
+      },
+      {
+        "version": "1.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.10.0 > v0.9.0",
+      {
+        "version": {
+          "$vgt": "v0.9.0"
+        }
+      },
+      {
+        "version": "0.10.0"
+      },
+      true
+    ],
+    [
+      "version 0.99.0 > v0.10.0",
+      {
+        "version": {
+          "$vgt": "v0.10.0"
+        }
+      },
+      {
+        "version": "0.99.0"
+      },
+      true
+    ],
+    [
+      "version 2.0.0 > v1.2.3",
+      {
+        "version": {
+          "$vgt": "v1.2.3"
+        }
+      },
+      {
+        "version": "2.0.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 > 1.2.3-asdf",
+      {
+        "version": {
+          "$vgt": "1.2.3-asdf"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 > 1.2.3-4",
+      {
+        "version": {
+          "$vgt": "1.2.3-4"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 > 1.2.3-4-foo",
+      {
+        "version": {
+          "$vgt": "1.2.3-4-foo"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-5-foo > 1.2.3-5",
+      {
+        "version": {
+          "$vgt": "1.2.3-5"
+        }
+      },
+      {
+        "version": "1.2.3-5-foo"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-5 > 1.2.3-4",
+      {
+        "version": {
+          "$vgt": "1.2.3-4"
+        }
+      },
+      {
+        "version": "1.2.3-5"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-5-foo > 1.2.3-5-Foo",
+      {
+        "version": {
+          "$vgt": "1.2.3-5-Foo"
+        }
+      },
+      {
+        "version": "1.2.3-5-foo"
+      },
+      true
+    ],
+    [
+      "version 3.0.0 > 2.7.2+asdf",
+      {
+        "version": {
+          "$vgt": "2.7.2+asdf"
+        }
+      },
+      {
+        "version": "3.0.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.10 > 1.2.3-a.5",
+      {
+        "version": {
+          "$vgt": "1.2.3-a.5"
+        }
+      },
+      {
+        "version": "1.2.3-a.10"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b > 1.2.3-a.5",
+      {
+        "version": {
+          "$vgt": "1.2.3-a.5"
+        }
+      },
+      {
+        "version": "1.2.3-a.b"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b > 1.2.3-a",
+      {
+        "version": {
+          "$vgt": "1.2.3-a"
+        }
+      },
+      {
+        "version": "1.2.3-a.b"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b.c.10.d.5 > 1.2.3-a.b.c.5.d.100",
+      {
+        "version": {
+          "$vgt": "1.2.3-a.b.c.5.d.100"
+        }
+      },
+      {
+        "version": "1.2.3-a.b.c.10.d.5"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-r2 > 1.2.3-r100",
+      {
+        "version": {
+          "$vgt": "1.2.3-r100"
+        }
+      },
+      {
+        "version": "1.2.3-r2"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-r100 > 1.2.3-R2",
+      {
+        "version": {
+          "$vgt": "1.2.3-R2"
+        }
+      },
+      {
+        "version": "1.2.3-r100"
+      },
+      true
+    ],
+    [
+      "version a.b.c.d.e.f > 1.2.3",
+      {
+        "version": {
+          "$vgt": "1.2.3"
+        }
+      },
+      {
+        "version": "a.b.c.d.e.f"
+      },
+      true
+    ],
+    [
+      "version 10.0.0 > 9.0.0",
+      {
+        "version": {
+          "$vgt": "9.0.0"
+        }
+      },
+      {
+        "version": "10.0.0"
+      },
+      true
+    ],
+    [
+      "version 10000.0.0 > 9999.0.0",
+      {
+        "version": {
+          "$vgt": "9999.0.0"
+        }
+      },
+      {
+        "version": "10000.0.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 == 1.2.3",
+      {
+        "version": {
+          "$veq": "1.2.3"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 == v1.2.3",
+      {
+        "version": {
+          "$veq": "v1.2.3"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-0 == v1.2.3-0",
+      {
+        "version": {
+          "$veq": "v1.2.3-0"
+        }
+      },
+      {
+        "version": "1.2.3-0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-1 == 1.2.3-1",
+      {
+        "version": {
+          "$veq": "1.2.3-1"
+        }
+      },
+      {
+        "version": "1.2.3-1"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-1 == v1.2.3-1",
+      {
+        "version": {
+          "$veq": "v1.2.3-1"
+        }
+      },
+      {
+        "version": "1.2.3-1"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta == 1.2.3-beta",
+      {
+        "version": {
+          "$veq": "1.2.3-beta"
+        }
+      },
+      {
+        "version": "1.2.3-beta"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta == v1.2.3-beta",
+      {
+        "version": {
+          "$veq": "v1.2.3-beta"
+        }
+      },
+      {
+        "version": "1.2.3-beta"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta+build == 1.2.3-beta+otherbuild",
+      {
+        "version": {
+          "$veq": "1.2.3-beta+otherbuild"
+        }
+      },
+      {
+        "version": "1.2.3-beta+build"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta+build == v1.2.3-beta+otherbuild",
+      {
+        "version": {
+          "$veq": "v1.2.3-beta+otherbuild"
+        }
+      },
+      {
+        "version": "1.2.3-beta+build"
+      },
+      true
+    ],
+    [
+      "version 1-2-3 == 1.2.3",
+      {
+        "version": {
+          "$veq": "1.2.3"
+        }
+      },
+      {
+        "version": "1-2-3"
+      },
+      true
+    ],
+    [
+      "version 1-2-3 == 1-2.3+build99",
+      {
+        "version": {
+          "$veq": "1-2.3+build99"
+        }
+      },
+      {
+        "version": "1-2-3"
+      },
+      true
+    ],
+    [
+      "version 1-2-3 == v1.2.3",
+      {
+        "version": {
+          "$veq": "v1.2.3"
+        }
+      },
+      {
+        "version": "1-2-3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3.4 == 1.2.3-4",
+      {
+        "version": {
+          "$veq": "1.2.3-4"
+        }
+      },
+      {
+        "version": "1.2.3.4"
+      },
+      true
+    ],
+    [
+      "$or pass but second condition fail",
+      {
+        "$or": [{ "foo": 1 }, { "bar": 1 }],
+        "baz": 2
+      },
+      {
+        "foo": 1,
+        "bar": 2,
+        "baz": 1
+      },
+      false
+    ],
+    [
+      "$or and second condition both pass",
+      {
+        "$or": [{ "foo": 1 }, { "bar": 1 }],
+        "baz": 2
+      },
+      {
+        "foo": 1,
+        "bar": 2,
+        "baz": 2
+      },
+      true
+    ],
+    [
+      "$and condition pass but $or fail",
+      {
+        "$and": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [{ "baz": 1 }, { "empty": 1 }]
+      },
+      {
+        "foo": 1,
+        "bar": 1,
+        "baz": 2
+      },
+      false
+    ],
+    [
+      "$and and $or both pass",
+      {
+        "$and": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [{ "baz": 1 }, { "empty": 1 }]
+      },
+      {
+        "foo": 1,
+        "bar": 1,
+        "baz": 2,
+        "empty": 1
+      },
+      true
+    ],
+    [
+      "$inGroup passes for member of known group id",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": 1 },
+      true,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$inGroup fails for non-member of known group id",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": 5 },
+      false,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$inGroup fails for unknown group id",
+      {
+        "id": { "$inGroup": "unknowngroup_id" }
+      },
+      { "id": 1 },
+      false,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$notInGroup fails for member of known group id",
+      {
+        "id": { "$notInGroup": "group_id" }
+      },
+      { "id": 1 },
+      false,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$notInGroup passes for non-member of known group id",
+      {
+        "id": { "$notInGroup": "group_id" }
+      },
+      { "id": 5 },
+      true,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$notInGroup passes for unknown group id",
+      {
+        "id": { "$notInGroup": "unknowngroup_id" }
+      },
+      { "id": 1 },
+      true,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$inGroup passes for properly typed data",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": "2" },
+      true,
+      { "group_id": [1, "2", 3] }
+    ],
+    [
+      "$inGroup fails for improperly typed data",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": "3" },
+      false,
+      { "group_id": [1, "2", 3] }
     ]
   ],
-  "versionCompare": {
-    "lt": [
-      ["0.9.99", "1.0.0", true],
-      ["0.9.0", "0.10.0", true],
-      ["1.0.0-0.0", "1.0.0-0.0.0", true],
-      ["1.0.0-9999", "1.0.0--", true],
-      ["1.0.0-99", "1.0.0-100", true],
-      ["1.0.0-alpha", "1.0.0-alpha.1", true],
-      ["1.0.0-alpha.1", "1.0.0-alpha.beta", true],
-      ["1.0.0-alpha.beta", "1.0.0-beta", true],
-      ["1.0.0-beta", "1.0.0-beta.2", true],
-      ["1.0.0-beta.2", "1.0.0-beta.11", true],
-      ["1.0.0-beta.11", "1.0.0-rc.1", true],
-      ["1.0.0-rc.1", "1.0.0", true],
-      ["1.0.0-0", "1.0.0--1", true],
-      ["1.0.0-0", "1.0.0-1", true],
-      ["1.0.0-1.0", "1.0.0-1.-1", true]
-    ],
-    "gt": [
-      ["0.0.0", "0.0.0-foo", true],
-      ["0.0.1", "0.0.0", true],
-      ["1.0.0", "0.9.9", true],
-      ["0.10.0", "0.9.0", true],
-      ["0.99.0", "0.10.0", true],
-      ["2.0.0", "1.2.3", true],
-      ["v0.0.0", "0.0.0-foo", true],
-      ["v0.0.1", "0.0.0", true],
-      ["v1.0.0", "0.9.9", true],
-      ["v0.10.0", "0.9.0", true],
-      ["v0.99.0", "0.10.0", true],
-      ["v2.0.0", "1.2.3", true],
-      ["0.0.0", "v0.0.0-foo", true],
-      ["0.0.1", "v0.0.0", true],
-      ["1.0.0", "v0.9.9", true],
-      ["0.10.0", "v0.9.0", true],
-      ["0.99.0", "v0.10.0", true],
-      ["2.0.0", "v1.2.3", true],
-      ["1.2.3", "1.2.3-asdf", true],
-      ["1.2.3", "1.2.3-4", true],
-      ["1.2.3", "1.2.3-4-foo", true],
-      ["1.2.3-5-foo", "1.2.3-5", true],
-      ["1.2.3-5", "1.2.3-4", true],
-      ["1.2.3-5-foo", "1.2.3-5-Foo", true],
-      ["3.0.0", "2.7.2+asdf", true],
-      ["1.2.3-a.10", "1.2.3-a.5", true],
-      ["1.2.3-a.b", "1.2.3-a.5", true],
-      ["1.2.3-a.b", "1.2.3-a", true],
-      ["1.2.3-a.b.c", "1.2.3-a.b.c.d", false],
-      ["1.2.3-a.b.c.10.d.5", "1.2.3-a.b.c.5.d.100", true],
-      ["1.2.3-r2", "1.2.3-r100", true],
-      ["1.2.3-r100", "1.2.3-R2", true],
-      ["a.b.c.d.e.f", "1.2.3", true],
-      ["10.0.0", "9.0.0", true],
-      ["10000.0.0", "9999.0.0", true]
-    ],
-    "eq": [
-      ["1.2.3", "1.2.3", true],
-      ["1.2.3", "v1.2.3", true],
-      ["1.2.3-0", "v1.2.3-0", true],
-      ["1.2.3-1", "1.2.3-1", true],
-      ["1.2.3-1", "v1.2.3-1", true],
-      ["1.2.3-beta", "1.2.3-beta", true],
-      ["1.2.3-beta", "v1.2.3-beta", true],
-      ["1.2.3-beta+build", "1.2.3-beta+otherbuild", true],
-      ["1.2.3-beta+build", "v1.2.3-beta+otherbuild", true],
-      ["1-2-3", "1.2.3", true],
-      ["1-2-3", "1-2.3+build99", true],
-      ["1-2-3", "v1.2.3", true],
-      ["1.2.3.4", "1.2.3-4", true]
-    ]
-  },
   "hash": [
     ["", "a", 1, 0.22],
     ["", "b", 1, 0.077],
@@ -2230,7 +3390,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "unknownFeature"
+        "source": "unknownFeature",
+        "ruleId": ""
       }
     ],
     [
@@ -2241,7 +3402,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -2252,7 +3414,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -2263,7 +3426,8 @@
         "value": "yes",
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -2285,7 +3449,32 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rule with rule id",
+      {
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "id": "a",
+                "force": 1
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": "a"
       }
     ],
     [
@@ -2307,7 +3496,8 @@
         "value": false,
         "on": false,
         "off": true,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -2333,7 +3523,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -2359,7 +3550,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -2373,6 +3565,7 @@
             "defaultValue": 2,
             "rules": [
               {
+                "id": "a",
                 "force": 1,
                 "coverage": 0.5
               }
@@ -2385,7 +3578,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -2409,7 +3603,36 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage 0",
+      {
+        "attributes": {
+          "id": "d0bc0a5a"
+        },
+        "features": {
+          "8d156": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "8d156",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -2439,7 +3662,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -2469,7 +3693,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -2496,7 +3721,64 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - hashVersion 2 includes user",
+      {
+        "attributes": {
+          "id": "user2"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - hashVersion 2 excludes user that v1 would include",
+      {
+        "attributes": {
+          "id": "user3"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -2513,7 +3795,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -2553,7 +3836,8 @@
           "key": "2",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": ""
       }
     ],
     [
@@ -2566,6 +3850,7 @@
           "feature": {
             "rules": [
               {
+                "id": "id",
                 "variations": ["a", "b", "c"]
               }
             ]
@@ -2593,7 +3878,8 @@
           "key": "0",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": "id"
       }
     ],
     [
@@ -2633,7 +3919,8 @@
           "key": "1",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": ""
       }
     ],
     [
@@ -2678,7 +3965,8 @@
                 "key": "hello",
                 "variations": [true, false],
                 "weights": [0.1, 0.9],
-                "condition": { "premium": true }
+                "condition": { "premium": true },
+                "foo": "bar"
               }
             ]
           }
@@ -2736,7 +4024,8 @@
           "key": "v1",
           "name": "variation 1",
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -2770,7 +4059,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -2785,13 +4075,16 @@
             "rules": [
               {
                 "force": 1,
+                "id": "1",
                 "condition": { "browser": "chrome" }
               },
               {
+                "id": "2",
                 "force": 2,
                 "condition": { "browser": "firefox" }
               },
               {
+                "id": "3",
                 "force": 3,
                 "condition": { "browser": "safari" }
               }
@@ -2804,7 +4097,8 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": "3"
       }
     ],
     [
@@ -2838,7 +4132,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -2865,7 +4160,8 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -2892,7 +4188,8 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -2931,7 +4228,8 @@
           "key": "1",
           "bucket": 0.863,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -2958,7 +4256,8 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3002,7 +4301,8 @@
           "hashValue": "123",
           "key": "1",
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -3029,7 +4329,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3056,7 +4357,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3082,7 +4384,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3113,7 +4416,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3141,7 +4445,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3208,7 +4513,8 @@
           "variationId": 0,
           "bucket": 0.4413,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -3281,7 +4587,8 @@
           "variationId": 0,
           "bucket": 0.8043,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -3301,9 +4608,7 @@
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": { "$in": ["USA", "Mexico"] }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -3333,7 +4638,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "prerequisite"
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -3370,7 +4676,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "prerequisite"
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -3390,9 +4697,7 @@
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": { "$in": ["USA", "Mexico"] }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -3422,7 +4727,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3442,9 +4748,7 @@
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": { "$in": ["USA", "Mexico"] }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -3492,7 +4796,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3521,9 +4826,7 @@
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": { "$in": ["USA", "Mexico"] }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -3562,7 +4865,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3614,7 +4918,61 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Prerequisite experiment flag in target bucket, evaluate skip dependent flag if not bucketed",
+      {
+        "attributes": {
+          "id": "1234",
+          "memberType": "basic",
+          "country": "USA"
+        },
+        "features": {
+          "parentExperimentFlag": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "experiment",
+                "variations": [0, 1],
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "ranges": [
+                  [0, 0.5],
+                  [0.5, 1.0]
+                ]
+              }
+            ]
+          },
+          "childFlag": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentExperimentFlag",
+                    "condition": { "value": 0 },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": { "memberType": "basic" },
+                "force": "success"
+              }
+            ]
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": null,
+        "on": false,
+        "off": true,
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -3659,7 +5017,161 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "cyclicPrerequisite"
+        "source": "cyclicPrerequisite",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Multiple references to same prerequisite, do not break",
+      {
+        "attributes": {
+          "id": "123",
+          "browser": "edge"
+        },
+        "features": {
+          "childFlag": {
+            "defaultValue": true,
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": { "value": { "$ne": false } },
+                    "gate": true
+                  },
+                  {
+                    "id": "parentFlag",
+                    "condition": { "value": true },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "browser": "safari"
+                },
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": { "value": true }
+                  }
+                ],
+                "force": "C"
+              },
+              {
+                "condition": {
+                  "browser": { "$ne": "safari" }
+                },
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": { "value": true }
+                  }
+                ],
+                "force": "T"
+              }
+            ]
+          },
+          "parentFlag": {
+            "defaultValue": true
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": "T",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "SavedGroups correctly pulled from context for force rule",
+      {
+        "attributes": {
+          "id": 123
+        },
+        "features": {
+          "inGroup_force_rule": {
+            "defaultValue": false,
+            "rules": [
+              {
+                "force": true,
+                "condition": { "id": { "$inGroup": "group_id" } }
+              }
+            ]
+          }
+        },
+        "savedGroups": {
+          "group_id": [123, 456]
+        }
+      },
+      "inGroup_force_rule",
+      {
+        "value": true,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "SavedGroups correctly pulled from context for experiment rule",
+      {
+        "attributes": {
+          "id": 123
+        },
+        "features": {
+          "inGroup_experiment_rule": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "experiment",
+                "condition": { "id": { "$inGroup": "group_id" } },
+                "hashVersion": 2,
+                "variations": [1, 2],
+                "ranges": [
+                  [0, 0.5],
+                  [0.5, 1.0]
+                ]
+              }
+            ]
+          }
+        },
+        "savedGroups": {
+          "group_id": [123, 456]
+        }
+      },
+      "inGroup_experiment_rule",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "hashVersion": 2,
+          "condition": { "id": { "$inGroup": "group_id" } },
+          "variations": [1, 2],
+          "ranges": [
+            [0, 0.5],
+            [0.5, 1.0]
+          ],
+          "key": "experiment"
+        },
+        "experimentResult": {
+          "featureId": "inGroup_experiment_rule",
+          "hashAttribute": "id",
+          "hashUsed": true,
+          "hashValue": 123,
+          "inExperiment": true,
+          "key": "0",
+          "value": 1,
+          "variationId": 0,
+          "bucket": 0.1736,
+          "stickyBucketUsed": false
+        },
+        "ruleId": ""
       }
     ]
   ],
@@ -4543,6 +6055,23 @@
       0,
       false,
       false
+    ],
+    [
+      "SavedGroups correctly pulled from context for experiment",
+      {
+        "attributes": { "id": "4" },
+        "savedGroups": { "group_id": ["4", "5", "6"] }
+      },
+      {
+        "key": "group-filtered-test",
+        "condition": {
+          "id": { "$inGroup": "group_id" }
+        },
+        "variations": [0, 1, 2]
+      },
+      0,
+      true,
+      true
     ]
   ],
   "chooseVariation": [
@@ -4813,6 +6342,7 @@
           }
         }
       },
+      [],
       "feature",
       {
         "bucket": 0.863,
@@ -4866,6 +6396,7 @@
         },
         "stickyBucketAssignmentDocs": {}
       },
+      [],
       "exp1",
       {
         "bucket": 0.6468,
@@ -4916,17 +6447,17 @@
               }
             ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "deviceId||d123": {
-            "attributeName": "deviceId",
-            "attributeValue": "d123",
-            "assignments": {
-              "feature-exp__0": "2"
-            }
-          }
         }
       },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__0": "2"
+          }
+        }
+      ],
       "exp1",
       {
         "bucket": 0.6468,
@@ -4949,76 +6480,10 @@
       }
     ],
     [
-      "upgrades a sticky bucket doc from a fallbackAttribute to a hashAttribute",
+      "does not consume a sticky bucket not belonging to the user",
       {
         "attributes": {
-          "id": "i123",
-          "anonymousId": "123",
-          "foo": "bar",
-          "country": "USA"
-        },
-        "features": {
-          "exp1": {
-            "defaultValue": "control",
-            "rules": [
-              {
-                "key": "feature-exp",
-                "seed": "feature-exp",
-                "hashAttribute": "id",
-                "fallbackAttribute": "anonymousId",
-                "hashVersion": 2,
-                "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
-                "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
-                "phase": "0"
-              }
-            ]
-          }
-        },
-        "stickyBucketAssignmentDocs": {
-          "anonymousId||123": {
-            "attributeName": "anonymousId",
-            "attributeValue": "123",
-            "assignments": {
-              "feature-exp__0": "2"
-            }
-          }
-        }
-      },
-      "exp1",
-      {
-        "bucket": 0.9943,
-        "featureId": "exp1",
-        "hashAttribute": "id",
-        "hashUsed": true,
-        "hashValue": "i123",
-        "inExperiment": true,
-        "key": "2",
-        "stickyBucketUsed": true,
-        "value": "blue",
-        "variationId": 2
-      },
-      {
-        "anonymousId||123": {
-          "assignments": { "feature-exp__0": "2" },
-          "attributeName": "anonymousId",
-          "attributeValue": "123"
-        },
-        "id||i123": {
-          "assignments": { "feature-exp__0": "2" },
-          "attributeName": "id",
-          "attributeValue": "i123"
-        }
-      }
-    ],
-    [
-      "favors a sticky bucket doc based on hashAttribute over fallbackAttribute",
-      {
-        "attributes": {
-          "id": "i123",
+          "deviceId": "d123",
           "anonymousId": "ses123",
           "foo": "bar",
           "country": "USA"
@@ -5043,24 +6508,78 @@
               }
             ]
           }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d456",
+          "assignments": {
+            "feature-exp__0": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": false,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "deviceId||d123": {
+          "assignments": { "feature-exp__0": "1" },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "upgrades a sticky bucket doc from a fallbackAttribute to a hashAttribute",
+      {
+        "attributes": {
+          "id": "i123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
         },
-        "stickyBucketAssignmentDocs": {
-          "anonymousId||123": {
-            "attributeName": "anonymousId",
-            "attributeValue": "123",
-            "assignments": {
-              "feature-exp__0": "2"
-            }
-          },
-          "id||i123": {
-            "attributeName": "id",
-            "attributeValue": "i123",
-            "assignments": {
-              "feature-exp__0": "1"
-            }
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "anonymousId",
+                "hashVersion": 2,
+                "bucketVersion": 0,
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "coverage": 1,
+                "weights": [0.3334, 0.3333, 0.3333],
+                "phase": "0"
+              }
+            ]
           }
         }
       },
+      [
+        {
+          "attributeName": "anonymousId",
+          "attributeValue": "ses123",
+          "assignments": {
+            "feature-exp__0": "1"
+          }
+        }
+      ],
       "exp1",
       {
         "bucket": 0.9943,
@@ -5075,10 +6594,83 @@
         "variationId": 1
       },
       {
-        "anonymousId||123": {
+        "anonymousId||ses123": {
+          "assignments": { "feature-exp__0": "1" },
+          "attributeName": "anonymousId",
+          "attributeValue": "ses123"
+        },
+        "id||i123": {
+          "assignments": { "feature-exp__0": "1" },
+          "attributeName": "id",
+          "attributeValue": "i123"
+        }
+      }
+    ],
+    [
+      "favors a sticky bucket doc based on hashAttribute over fallbackAttribute",
+      {
+        "attributes": {
+          "id": "i123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "anonymousId",
+                "hashVersion": 2,
+                "bucketVersion": 0,
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "coverage": 1,
+                "weights": [0.3334, 0.3333, 0.3333],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "anonymousId",
+          "attributeValue": "ses123",
+          "assignments": {
+            "feature-exp__0": "2"
+          }
+        },
+        {
+          "attributeName": "id",
+          "attributeValue": "i123",
+          "assignments": {
+            "feature-exp__0": "1"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.9943,
+        "featureId": "exp1",
+        "hashAttribute": "id",
+        "hashUsed": true,
+        "hashValue": "i123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": true,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "anonymousId||ses123": {
           "assignments": { "feature-exp__0": "2" },
           "attributeName": "anonymousId",
-          "attributeValue": "123"
+          "attributeValue": "ses123"
         },
         "id||i123": {
           "assignments": { "feature-exp__0": "1" },
@@ -5115,15 +6707,15 @@
               }
             ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "id||i123": {
-            "assignments": { "feature-exp__0": "1" },
-            "attributeName": "id",
-            "attributeValue": "i123"
-          }
         }
       },
+      [
+        {
+          "assignments": { "feature-exp__0": "1" },
+          "attributeName": "id",
+          "attributeValue": "i123"
+        }
+      ],
       "exp1",
       {
         "bucket": 0.9943,
@@ -5177,15 +6769,15 @@
               }
             ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "id||i123": {
-            "assignments": { "feature-exp__0": "1" },
-            "attributeName": "id",
-            "attributeValue": "i123"
-          }
         }
       },
+      [
+        {
+          "assignments": { "feature-exp__0": "1" },
+          "attributeName": "id",
+          "attributeValue": "i123"
+        }
+      ],
       "exp1",
       null,
       {
@@ -5195,6 +6787,249 @@
           },
           "attributeName": "id",
           "attributeValue": "i123"
+        }
+      }
+    ],
+    [
+      "uses a sticky bucket when sticky bucket version == experiment.minBucketVersion === experiment.bucketVersion",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "coverage": 1,
+                "weights": [0.3334, 0.3333, 0.3333],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__3": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "2",
+        "stickyBucketUsed": true,
+        "value": "blue",
+        "variationId": 2
+      },
+      {
+        "deviceId||d123": {
+          "assignments": { "feature-exp__3": "2" },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "skips assignment when sticky bucket version < experiment.minBucketVersion",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "coverage": 1,
+                "weights": [0.3334, 0.3333, 0.3333],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__2": "2"
+          }
+        }
+      ],
+      "exp1",
+      null,
+      {
+        "deviceId||d123": {
+          "assignments": { "feature-exp__2": "2" },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "resets sticky bucketing when bucket version > experiment.bucketVersion (invalid version)",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "coverage": 1,
+                "weights": [0.3334, 0.3333, 0.3333],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__4": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": false,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__3": "1",
+            "feature-exp__4": "2"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "resets sticky bucketing when bucket version < experiment.bucketVersion (invalid version)",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 4,
+                "minBucketVersion": 3,
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "coverage": 1,
+                "weights": [0.3334, 0.3333, 0.3333],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__3": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": false,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__3": "2",
+            "feature-exp__4": "1"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
         }
       }
     ],
@@ -5227,15 +7062,15 @@
               }
             ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "id||i123": {
-            "attributeName": "id",
-            "attributeValue": "i123",
-            "assignments": { "feature-exp__0": "1" }
-          }
         }
       },
+      [
+        {
+          "attributeName": "id",
+          "attributeValue": "i123",
+          "assignments": { "feature-exp__0": "1" }
+        }
+      ],
       "exp1",
       {
         "bucket": 0.9943,

--- a/spec/growthbook/context_spec.rb
+++ b/spec/growthbook/context_spec.rb
@@ -138,6 +138,7 @@ describe Growthbook::Context do
             'off'              => false,
             'value'            => 2,
             'source'           => 'experiment',
+            'ruleId'           => '',
             'experiment'       => {
               'key'        => 'feature1',
               'variations' => [2, 3]

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -114,13 +114,14 @@ describe 'test suite' do
     # Loop through each test case in the JSON file
     test_cases['evalCondition'].each do |test_case|
       # Extract data about the test case
-      test_name, condition, attributes, expected = test_case
+      test_name, condition, attributes, expected, saved_groups = test_case
 
       # Run the actual test case
       it test_name do
         result = Growthbook::Conditions.eval_condition(
           attributes,
-          condition
+          condition,
+          saved_groups || {}
         )
         expect(result).to eq(expected)
       end

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -173,10 +173,14 @@ describe 'test suite' do
 
   describe 'stickyBucket' do
     test_cases['stickyBucket'].each do |test_case|
-      test_name, ctx, key, expected_result, expected_docs = test_case
+      test_name, ctx, initial_docs, key, expected_result, expected_docs = test_case
 
       it test_name do
         service = Growthbook::InMemoryStickyBucketService.new
+
+        # Pre-load any initial sticky bucket assignment docs (spec 0.7.x positional field)
+        (initial_docs || []).each { |doc| service.save_assignments(doc) }
+
         ctx['sticky_bucket_service'] = service
 
         ctx['sticky_bucket_identifier_attributes'] = ctx.delete('stickyBucketIdentifierAttributes') if ctx.key?('stickyBucketIdentifierAttributes')
@@ -192,7 +196,10 @@ describe 'test suite' do
           expect(res.experiment_result.to_json).to eq(expected_result)
         end
 
-        expect(service.assignments).to eq(expected_docs)
+        # Each expected doc must match; extra docs in the service are ignored
+        expected_docs.each do |doc_key, value|
+          expect(service.assignments[doc_key]).to eq(value)
+        end
       end
     end
   end


### PR DESCRIPTION
Brings the Ruby SDK up to spec **0.7.1** (from 0.5.4), matching the current
  PHP/Python SDKs. Updates the shared conformance corpus, implements the
  features it requires, and fixes several pre-existing bugs it surfaces.

  ### Features
  - `ruleId` on feature results
  - Saved groups: `$inGroup` / `$notInGroup` operators + `savedGroups` context option
  - Case-insensitive operators: `$ini` / `$nini` / `$regexi` / `$alli`

  ### Fixes (pre-existing bugs surfaced by the 0.7.1 corpus)
  - Compound conditions (`$or`/`$nor`/`$and`/`$not`) no longer ignore sibling keys
  - `coverage: 0` rollout/force rules now exclude everyone
  - Prerequisites referenced multiple times are no longer mis-flagged as cyclic
  - Boolean `$eq`/`$ne` (e.g. `{value: {$ne: false}}`) now evaluate correctly

  ### Tests
  - `spec/cases.json` updated to the official 0.7.1 corpus
  - Full suite green (508 examples, 0 failures); RBS/Steep + RuboCop updated to match

  ### CI
  - Pin `rbs` to 3.4.4 in the type-check job (Steep 1.6.0 hangs on rbs 3.x's `UntypedFunction`)