### PR TITLE
Parse saved groups from the feature repository

### DIFF
--- a/lib/growthbook/feature_repository.rb
+++ b/lib/growthbook/feature_repository.rb
@@ -15,10 +15,14 @@ module Growthbook
     # Parsed features JSON
     attr_reader :features_json
 
+    # Parsed saved groups JSON (used by the $inGroup/$notInGroup operators)
+    attr_reader :saved_groups_json
+
     def initialize(endpoint:, decryption_key:)
       @endpoint = endpoint
       @decryption_key = decryption_key
       @features_json = {}
+      @saved_groups_json = {}
     end
 
     def fetch
@@ -56,7 +60,11 @@ module Growthbook
     end
 
     def parsed_plain_text_response
-      @features_json = parsed_response['features'] unless parsed_response.nil?
+      parsed = parsed_response
+      return nil if parsed.nil?
+
+      @saved_groups_json = parsed['savedGroups'] || {}
+      @features_json = parsed['features']
     rescue StandardError
       nil
     end
@@ -65,10 +73,24 @@ module Growthbook
       k = decryption_key
       return nil if k.nil?
 
-      decrypted_str = Growthbook::DecryptionUtil.decrypt(parsed_response['encryptedFeatures'], key: k)
+      parsed = parsed_response
+      return nil if parsed.nil?
+
+      @saved_groups_json = decrypted_saved_groups(parsed, k)
+
+      decrypted_str = Growthbook::DecryptionUtil.decrypt(parsed['encryptedFeatures'], key: k)
       @features_json = JSON.parse(decrypted_str) unless decrypted_str.nil?
     rescue StandardError
       nil
+    end
+
+    def decrypted_saved_groups(parsed, key)
+      if parsed['encryptedSavedGroups']
+        decrypted = Growthbook::DecryptionUtil.decrypt(parsed['encryptedSavedGroups'], key: key)
+        return JSON.parse(decrypted) unless decrypted.nil?
+      end
+
+      parsed['savedGroups'] || {}
     end
 
     def parsed_response

--- a/sig/lib/growthbook/feature_repository.rbs
+++ b/sig/lib/growthbook/feature_repository.rbs
@@ -6,6 +6,7 @@ module Growthbook
     attr_reader endpoint: String
     attr_reader decryption_key: String?
     attr_reader features_json: Hash[String, untyped]
+    attr_reader saved_groups_json: Hash[String, untyped]
 
     def fetch: () -> (nil | Hash[String, untyped])
 
@@ -18,6 +19,8 @@ module Growthbook
     def parsed_plain_text_response: () -> (nil | Hash[String, untyped])
 
     def parsed_decrypted_response: () -> (nil | Hash[String, untyped])
+
+    def decrypted_saved_groups: (Hash[String, untyped] parsed, String key) -> Hash[String, untyped]
 
     def parsed_response: () -> (nil | Hash[String, untyped])
 

--- a/spec/growthbook/feature_repository_spec.rb
+++ b/spec/growthbook/feature_repository_spec.rb
@@ -386,4 +386,71 @@ RSpec.describe Growthbook::FeatureRepository do
       end
     end
   end
+
+  describe '#saved_groups_json' do
+    subject(:repository) do
+      described_class.new(endpoint: endpoint, decryption_key: decryption_key)
+    end
+
+    before do
+      stub_request(:get, endpoint)
+        .to_return(status: 200, body: json_response, headers: {})
+    end
+
+    context 'when the payload includes savedGroups' do
+      let(:decryption_key) { nil }
+      let(:endpoint) { 'https://cdn.growthbook.io/api/features/sdk-with-groups' }
+      let(:json_response) do
+        <<~JSON
+          {
+            "status": 200,
+            "features": {},
+            "savedGroups": { "admins": ["user-1", "user-2"], "beta": [123, 456] }
+          }
+        JSON
+      end
+
+      it 'exposes the parsed saved groups' do
+        repository.fetch
+        expect(repository.saved_groups_json).to eq(
+          'admins' => %w[user-1 user-2],
+          'beta'   => [123, 456]
+        )
+      end
+    end
+
+    context 'when the payload has no savedGroups' do
+      let(:decryption_key) { nil }
+      let(:endpoint) { 'https://cdn.growthbook.io/api/features/sdk-no-groups' }
+      let(:json_response) { '{ "status": 200, "features": {} }' }
+
+      it 'defaults to an empty hash' do
+        repository.fetch
+        expect(repository.saved_groups_json).to eq({})
+      end
+    end
+
+    context 'when the payload includes encryptedSavedGroups' do
+      let(:decryption_key) { 'BhB1wORFmZLTDjbvstvS8w==' }
+      let(:endpoint) { 'https://cdn.growthbook.io/api/features/sdk-encrypted-groups' }
+      let(:json_response) do
+        <<~JSON
+          {
+            "status": 200,
+            "features": {},
+            "encryptedFeatures": "Utj/Xwn7YaTXX8vHosRFQg==.yYuNdFoTv1aebOyhC7lTUpNSUW9toE4nSTMATKaT3mGwrzUUMrGg/3uJ0edpxRdoZcAD778+eDBlT9+i/wc+eMzBTK9KkEWSZG/hljlZjRP8zVbfggm/yy1E87xsGl1JnSkQ+iRyMTsrdEvvo2AkoQqFbmEOvOklcYAIZTMaYsgCOi+9BRbI1s6HLpI/kCE4kcuhePY0b20oWrpDL++wDQ==",
+            "encryptedSavedGroups": "jUmZ+agHSAI5JKtNty1zqQ==.rkUx/e1//+46KeWjlZQGb4rtj/1t6FUVpkrCQJiyEJ/+qmsrAEsVh7tLRZA+eskF"
+          }
+        JSON
+      end
+
+      it 'exposes the decrypted saved groups' do
+        repository.fetch
+        expect(repository.saved_groups_json).to eq(
+          'admins' => %w[user-1 user-2],
+          'beta'   => [123, 456]
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
 `FeatureRepository` now exposes `savedGroups` (and decrypts `encryptedSavedGroups`)
  from the API payload via the `saved_groups_json` accessor, so they can be passed
  into the context for the `$inGroup` / `$notInGroup` operators.

  Complements #<PR spec-0.7.1>, which adds those operators and the `savedGroups`
  context option — this PR wires up loading them from the API.

  ### CI
  - Pin `rbs` to 3.4.4 so the Steep type-check job doesn't hang (Steep 1.6.0 is
    incompatible with rbs 3.x's `UntypedFunction`). Shared with #35;
    if that merges first, this line becomes redundant.

  Tests: full suite green; RuboCop + Steep clean.