### PR TITLE
Declare base64 and bigdecimal as runtime dependencies (Ruby 3.4+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           bundler-cache: true
       - name: RBS type checking with Steep
         run: |
+          gem install rbs -v 3.4.4
           gem install steep -v 1.6.0
           steep check --log-level=fatal
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     growthbook (1.3.0)
       base64
+      bigdecimal
 
 GEM
   remote: https://rubygems.org/
@@ -10,6 +11,7 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     base64 (0.3.0)
+    bigdecimal (3.3.1)
     crack (0.4.5)
       rexml
     diff-lcs (1.4.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,14 @@ PATH
   remote: .
   specs:
     growthbook (1.3.0)
+      base64
 
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.3.0)
     crack (0.4.5)
       rexml
     diff-lcs (1.4.4)

--- a/growthbook.gemspec
+++ b/growthbook.gemspec
@@ -13,8 +13,9 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.5.0'
 
-  # base64 is no longer a default gem starting from Ruby 3.4, so declare it explicitly
+  # base64 and bigdecimal are no longer default gems starting from Ruby 3.4, so declare them explicitly
   s.add_dependency 'base64'
+  s.add_dependency 'bigdecimal'
 
   s.add_development_dependency 'rspec', '~> 3.2'
   s.add_development_dependency 'rspec-its', '~> 1.3'

--- a/growthbook.gemspec
+++ b/growthbook.gemspec
@@ -13,6 +13,9 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.5.0'
 
+  # base64 is no longer a default gem starting from Ruby 3.4, so declare it explicitly
+  s.add_dependency 'base64'
+
   s.add_development_dependency 'rspec', '~> 3.2'
   s.add_development_dependency 'rspec-its', '~> 1.3'
   s.add_development_dependency 'simplecov', '~> 0.21'


### PR DESCRIPTION
`base64` and `bigdecimal` stopped being default gems in Ruby 3.4, so the
  SDK failed to load for those users:
  - `require 'base64'` in `DecryptionUtil`
  - `require 'bigdecimal'` in `util.rb`

  Declare both explicitly in the gemspec.

  ### Done
  - gemspec: `s.add_dependency 'base64'` + `s.add_dependency 'bigdecimal'`
  - Gemfile.lock: `base64 0.3.0` + `bigdecimal 3.3.1` (both support Ruby >= 2.5 — the CI matrix)
  - CI: pin `rbs` 3.4.4 so the Steep type-check job doesn't hang

  These two are the only stdlib gems the SDK requires that 3.4 dropped from
  defaults (`json` / `openssl` / `uri` / `net/http` are still default gems).