### PR TITLE
Title: Add customFields to FeatureRule and InlineExperiment

### DIFF
--- a/lib/growthbook/feature_rule.rb
+++ b/lib/growthbook/feature_rule.rb
@@ -72,6 +72,9 @@ module Growthbook
     # @return [Array<Hash>] Array of prerequisite flags
     attr_accessor :parent_conditions
 
+    # @return [Hash, nil] Arbitrary custom fields attached to the rule
+    attr_reader :custom_fields
+
     def initialize(rule)
       @id = get_option(rule, :id)
       @coverage = get_option(rule, :coverage)
@@ -99,6 +102,7 @@ module Growthbook
       @bucket_version = get_option(rule, :bucket_version) || get_option(rule, :bucketVersion) || 0
       @min_bucket_version = get_option(rule, :min_bucket_version) || get_option(rule, :minBucketVersion) || 0
       @parent_conditions = get_option(rule, :parent_conditions) || get_option(rule, :parentConditions) || []
+      @custom_fields = get_option(rule, :custom_fields) || get_option(rule, :customFields)
 
       return unless @disable_sticky_bucketing
 
@@ -127,7 +131,8 @@ module Growthbook
         fallback_attribute: @fallback_attribute,
         disable_sticky_bucketing: @disable_sticky_bucketing,
         bucket_version: @bucket_version,
-        min_bucket_version: @min_bucket_version
+        min_bucket_version: @min_bucket_version,
+        custom_fields: @custom_fields
       )
     end
 

--- a/lib/growthbook/inline_experiment.rb
+++ b/lib/growthbook/inline_experiment.rb
@@ -66,6 +66,9 @@ module Growthbook
     # @return [Array<Hash>] Array of prerequisite flags
     attr_accessor :parent_conditions
 
+    # @return [Hash, nil] Arbitrary custom fields attached to the experiment
+    attr_accessor :custom_fields
+
     def initialize(options = {})
       @key = get_option(options, :key, '').to_s
       @variations = get_option(options, :variations, [])
@@ -88,6 +91,7 @@ module Growthbook
       @bucket_version = get_option(options, :bucket_version) || get_option(options, :bucketVersion) || 0
       @min_bucket_version = get_option(options, :min_bucket_version) || get_option(options, :minBucketVersion) || 0
       @parent_conditions = get_option(options, :parent_conditions) || get_option(options, :parentConditions) || []
+      @custom_fields = get_option(options, :custom_fields) || get_option(options, :customFields)
 
       return unless @disable_sticky_bucketing
 

--- a/sig/lib/growthbook/feature_rule.rbs
+++ b/sig/lib/growthbook/feature_rule.rbs
@@ -72,6 +72,9 @@ module Growthbook
     # @return [TrackData[] , nil] Array of tracking calls to fire
     attr_reader tracks: Array[{ experiment: untyped, result: untyped }]?
 
+    # @return [Hash, nil] Arbitrary custom fields attached to the rule
+    attr_reader custom_fields: Hash[String, untyped]?
+
     def initialize: (untyped rule) -> void
 
     # @return [Growthbook::InlineExperiment, nil]

--- a/sig/lib/growthbook/inline_experiment.rbs
+++ b/sig/lib/growthbook/inline_experiment.rbs
@@ -64,6 +64,9 @@ module Growthbook
     # @return [Array<Hash>] Array of prerequisite flags
     attr_accessor parent_conditions: Array[{id: string, gate: bool?, condition: Hash[String, untyped]}]
 
+    # @return [Hash, nil] Arbitrary custom fields attached to the experiment
+    attr_accessor custom_fields: Hash[String, untyped]?
+
     def initialize: (?::Hash[untyped, untyped] options) -> void
 
     def to_json: (*untyped _args) -> Hash[String, untyped]

--- a/spec/growthbook/custom_fields_spec.rb
+++ b/spec/growthbook/custom_fields_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'growthbook'
+
+RSpec.describe 'customFields' do
+  describe Growthbook::InlineExperiment do
+    it 'reads custom_fields from options' do
+      exp = described_class.new(variations: [0, 1], custom_fields: { 'team' => 'growth' })
+      expect(exp.custom_fields).to eq('team' => 'growth')
+    end
+
+    it 'accepts the camelCase customFields key' do
+      exp = described_class.new(variations: [0, 1], customFields: { 'team' => 'growth' })
+      expect(exp.custom_fields).to eq('team' => 'growth')
+    end
+
+    it 'defaults to nil when absent' do
+      exp = described_class.new(variations: [0, 1])
+      expect(exp.custom_fields).to be_nil
+    end
+  end
+
+  describe Growthbook::FeatureRule do
+    it 'reads custom_fields and forwards them to the experiment' do
+      rule = described_class.new(
+        'variations'   => [0, 1],
+        'customFields' => { 'owner' => 'team-a', 'priority' => 3 }
+      )
+
+      expect(rule.custom_fields).to eq('owner' => 'team-a', 'priority' => 3)
+      expect(rule.to_experiment('my-feature').custom_fields).to eq('owner' => 'team-a', 'priority' => 3)
+    end
+
+    it 'defaults to nil when absent' do
+      rule = described_class.new('variations' => [0, 1])
+      expect(rule.custom_fields).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
 Add the optional customFields property to FeatureRule and InlineExperiment,
  matching the PHP/Python SDKs. Exposed via `#custom_fields` for consumers (e.g. tracking).

  ### Done
  - `FeatureRule#custom_fields`, forwarded to its experiment
  - `InlineExperiment#custom_fields` (snake_case + camelCase keys)
  - RBS signatures + unit tests

  ### CI
  - Pin `rbs` 3.4.4 so the Steep type-check job doesn't hang (Steep 1.6.0 is
    incompatible with rbs 3.x)